### PR TITLE
Importing an empty array of objects/values should not raise an exception.

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -178,6 +178,9 @@ class ActiveRecord::Base
             end
           # end
         end
+        # supports empty array
+      elsif args.last.is_a?( Array ) and args.last.empty?
+        return ActiveRecord::Import::Result.new([], 0) if args.last.empty?
         # supports 2-element array and array
       elsif args.size == 2 and args.first.is_a?( Array ) and args.last.is_a?( Array )
         column_names, array_of_attributes = args

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -12,6 +12,13 @@ describe "#import" do
     end
   end
 
+  it "should not produce an error when importing empty arrays" do
+    assert_nothing_raised do
+      Topic.import []
+      Topic.import %w(title author_name), []
+    end
+  end
+
   context "with :validation option" do
     let(:columns) { %w(title author_name) }
     let(:valid_values) { [[ "LDAP", "Jerry Carter"], ["Rails Recipes", "Chad Fowler"]] }


### PR DESCRIPTION
Hello,

I've noticed importing an empty array (or an empty set of values) is raising an exception. So one must do

```
Foo.import some_empty_array unless some_empty_array.empty?
```

while we could simply test a returned result like

```
ActiveRecord::Import::Result.new([], 0)
```

In any case, thanks for this great gem!
