### PR TITLE
Ruby 1.9.2 / RubyGems 1.8.5 compatibility fix (pass String instead of Pathname to require)

### DIFF
--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -23,6 +23,6 @@ end
 
 
 this_dir = Pathname.new File.dirname(__FILE__)
-require this_dir.join("import")
-require this_dir.join("active_record/adapters/abstract_adapter")
-require this_dir.join("synchronize")
+require this_dir.join("import").to_s
+require this_dir.join("active_record/adapters/abstract_adapter").to_s
+require this_dir.join("synchronize").to_s


### PR DESCRIPTION
We need this small fix (cast Pathname objects to String prior to sending them to 'require') for compatibility with Ruby 1.9.2 / RubyGems 1.8.5.

```
/Users/fallwith/.rvm/rubies/ruby-1.9.2-head/lib/ruby/site_ruby/1.9.1/rubygems.rb:971:in `escape': can't convert Pathname to String (TypeError)
from /Users/fallwith/.rvm/rubies/ruby-1.9.2-head/lib/ruby/site_ruby/1.9.1/rubygems.rb:971:in `block in loaded_path?'
```

Regexp.escape which is called by Gem.loaded_path? (/usr/local/lib/ruby/site_ruby/1.9.1/rubygems.rb) expects the path as a String, not a Pathname. Convert Pathnames to Strings prior to calling 'require'
