### PR TITLE
Relax pg version dependency a bit.  The Gemfile specifies pg  ~>0.9.0 and

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   platforms :ruby do
     gem "mysql", "~> 2.8.1"
     gem "mysql2", "~> 0.2.4"
-    gem "pg", "~> 0.9.0"
+    gem "pg", "~> 0.9"
     gem "sqlite3-ruby", "~> 1.3.1"
   end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     multi_json (1.0.3)
     mysql (2.8.1)
     mysql2 (0.2.7)
-    pg (0.9.0)
+    pg (0.11.0)
     rake (0.8.7)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
@@ -76,7 +76,7 @@ DEPENDENCIES
   jeweler (>= 1.4.0)
   mysql (~> 2.8.1)
   mysql2 (~> 0.2.4)
-  pg (~> 0.9.0)
+  pg (~> 0.9)
   rake
   ruby-debug (= 0.10.4)
   ruby-debug-base (= 0.10.4)


### PR DESCRIPTION
Relax pg version dependency a bit.  The Gemfile specifies pg  ~>0.9.0 and Rails 3.1 specifies pg 0.11 so there is no way for bundler to install pg for a new download.

This is the error that I was getting:

Please install the postgresql adapter: `gem install activerecord-postgresql-adapter` (can't activate pg (~> 0.11), already activated pg-0.9.0. Make sure all dependencies are added to Gemfile.) (RuntimeError)
