### PR TITLE
Add failing test for really BIG imports.

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -19,6 +19,10 @@ describe "#import" do
     end
   end
 
+  it "should not produce an error for a very large number of rows" do
+    assert_nothing_raised {Topic.import Build(150000, :topics)}
+  end
+
   context "with :validation option" do
     let(:columns) { %w(title author_name) }
     let(:valid_values) { [[ "LDAP", "Jerry Carter"], ["Rails Recipes", "Chad Fowler"]] }

--- a/test/postgresql/import_test.rb
+++ b/test/postgresql/import_test.rb
@@ -17,8 +17,4 @@ describe "#import" do
       assert_equal 1, result.num_inserts
     end
   end
-
-  it "should work for a very large number of rows" do
-    !assert_raises {Topic.import Build(150000, :topics)}
-  end
 end


### PR DESCRIPTION
Add failing test for really BIG imports.  The test takes a long time to run but may be an important use case for this gem.
