### PR TITLE
Use connection pool instead of actual connection on load (helps with Rails 3.1 on Heroku)

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -2,15 +2,15 @@ class ActiveRecord::Base
   class << self
     def establish_connection_with_activerecord_import(*args)
       establish_connection_without_activerecord_import(*args)
-      ActiveSupport.run_load_hooks(:active_record_connection_established, connection)
+      ActiveSupport.run_load_hooks(:active_record_connection_established, connection_pool)
     end
     alias_method_chain :establish_connection, :activerecord_import
   end
 end
 
-ActiveSupport.on_load(:active_record_connection_established) do |connection|
-  if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection)
+ActiveSupport.on_load(:active_record_connection_established) do |connection_pool|
+  if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
     require File.join File.dirname(__FILE__),  "activerecord-import/base"
   end
-  ActiveRecord::Import.load_from_connection connection
+  ActiveRecord::Import.load_from_connection_pool connection_pool
 end

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -12,12 +12,8 @@ module ActiveRecord::Import
   end
 
   # Loads the import functionality for the passed in ActiveRecord connection
-  def self.load_from_connection(connection)
-    import_adapter = "ActiveRecord::Import::#{connection.class.name.demodulize}::InstanceMethods"
-    unless connection.class.ancestors.map(&:name).include?(import_adapter)
-      config = connection.instance_variable_get :@config
-      require_adapter config[:adapter]
-    end
+  def self.load_from_connection_pool(connection_pool)
+    require_adapter connection_pool.spec.config[:adapter]
   end
 end
 


### PR DESCRIPTION
In a Rails 3.1 app running on Heroku, the slug compiler will try to run `rake assets:precompile` when you push a new version of the app.  When it does that, the DATABASE_URL for the app hasn't yet been set up, so if the app tries to connect to the database during asset compilation, this will fail.

(For more information on this issue, see [Heroku's article on the topic](http://devcenter.heroku.com/articles/rails31_heroku_cedar#troubleshooting).)

activerecord-import ends up always connecting to the database during app bootup.  The reason for this is that `ActiveRecord::Base#establish_connection` is called on bootup with the parameters from database.yml.  Under normal circumstances, this doesn't cause a database connection attempt right away; rather, it simply sets up the connection pool object.  activerecord-import modifies this behavior, perhaps inadvertently, by calling the `connection` method in order to pass an active connection object into `load_from_connection`.

This patch changes the behavior: `load_from_connection` is replaced by `load_from_connection_pool`, which uses an `ActiveRecord::ConnectionAdapters::ConnectionPool` object instead.  We can introspect this object to figure out which adapter is used without needing to actually establish a database connection.

Note: this patch also removes the check to see whether the adapter extensions are already loaded in the adapter class.  I couldn't figure out a good way to determine the adapter class from the connection pool (the connection pool does this by calling `ActiveRecord.#{adapter_name}_connection`, which attempts to connect to the database).  But given the behavior of `Kernel#require` is not to require the same file twice, removing this check should be harmless.  I've run the tests for mysql and sqlite3, and everything still passes with this change.
