### PR TITLE
Sql server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :test do
     gem "mysql2", "~> 0.2.4"
     gem "pg", "~> 0.9"
     gem "sqlite3-ruby", "~> 1.3.1"
+    gem "activerecord-sqlserver-adapter", "~>3.2.0"
+    gem "tiny_tds"
   end
 
   platforms :jruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
     activerecord-jdbcmysql-adapter (1.1.1)
       activerecord-jdbc-adapter (= 1.1.1)
       jdbc-mysql (~> 5.1.0)
+    activerecord-sqlserver-adapter (3.2.0)
+      activerecord (~> 3.2.0)
     activesupport (3.2.0)
       i18n (~> 0.6)
       multi_json (~> 1.0)
@@ -58,6 +60,7 @@ GEM
     sqlite3 (1.3.5)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
+    tiny_tds (0.5.1)
     tzinfo (0.3.31)
 
 PLATFORMS
@@ -67,6 +70,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 3.0)
   activerecord-jdbcmysql-adapter
+  activerecord-sqlserver-adapter (~> 3.2.0)
   delorean (~> 0.2.0)
   factory_girl (~> 1.3.3)
   jdbc-mysql
@@ -79,3 +83,4 @@ DEPENDENCIES
   ruby-debug-base (= 0.10.4)
   ruby-debug19
   sqlite3-ruby (~> 1.3.1)
+  tiny_tds

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ namespace :display do
 end
 task :default => ["display:notice"]
 
-ADAPTERS = %w(mysql mysql2 jdbcmysql postgresql sqlite3)
+ADAPTERS = %w(mysql mysql2 jdbcmysql postgresql sqlite3 sqlserver)
 ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."

--- a/lib/activerecord-import/active_record/adapters/sqlserver_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/sqlserver_adapter.rb
@@ -1,0 +1,6 @@
+require "active_record/connection_adapters/sqlserver_adapter"
+require "activerecord-import/adapters/sqlserver_adapter"
+
+class ActiveRecord::ConnectionAdapters::SQLServerAdapter
+  include ActiveRecord::Import::SQLServerAdapter
+end

--- a/lib/activerecord-import/adapters/sqlserver_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlserver_adapter.rb
@@ -1,0 +1,15 @@
+module ActiveRecord::Import::SQLServerAdapter
+  include ActiveRecord::Import::ImportSupport
+
+  # There is a limit of 1000 rows on the insert method
+  # We need to process it in batches
+  def insert_many( sql, values, *args ) # :nodoc:
+    number_of_inserts = 0
+    while !(batch = values.shift(1000)).blank? do
+      # cloning sql here since the super method is modifying it
+      number_of_inserts += super( sql.clone, batch, args )
+    end
+    number_of_inserts
+  end
+
+end

--- a/test/adapters/sqlserver.rb
+++ b/test/adapters/sqlserver.rb
@@ -1,0 +1,1 @@
+ENV["ARE_DB"] = "sqlserver"


### PR DESCRIPTION
Hi,

This branch adds basic support for SQL Server.

Some tests are failing but it's due to the fact that SQL Server doesn't accepts null insertion into primary keys.
ie:
`INSERT INTO [group] ([id],[order],[created_at],[updated_at]) VALUES (NULL,''superx'',''2012-02-03T17:32:29.796'',''2012-02-03T17:32:29.796'')`
should be:
`INSERT INTO [group] ([order],[created_at],[updated_at]) VALUES (''superx'',''2012-02-03T17:32:29.796'',''2012-02-03T17:32:29.796'')`

Tested with SQL Server 2008 and ruby 1.9.2
