### PR TITLE
Support rgeo spatial database adapter names

### DIFF
--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -5,10 +5,19 @@ require "active_record/version"
 module ActiveRecord::Import
   AdapterPath = File.join File.expand_path(File.dirname(__FILE__)), "/active_record/adapters"
 
+  def self.base_adapter(adapter)
+    case adapter
+    when 'mysqlspatial' then 'mysql'
+    when 'spatialite' then 'sqlite3'
+    when 'postgis' then 'postgresql'
+    else adapter
+    end
+  end
+  
   # Loads the import functionality for a specific database adapter
   def self.require_adapter(adapter)
     require File.join(AdapterPath,"/abstract_adapter")
-    require File.join(AdapterPath,"/#{adapter}_adapter")
+    require File.join(AdapterPath,"/#{base_adapter(adapter)}_adapter")
   end
 
   # Loads the import functionality for the passed in ActiveRecord connection


### PR DESCRIPTION
Support the special mysqlspatial, postgis and spatialite adapter names created in the associated rgeo activerecord adapters.

This is a simpler change than pull request [31](https://github.com/zdennis/activerecord-import/pull/31) for postgis support.
