### PR TITLE
The jdbcmysql_adapter was left out of the InstanceMethods refactoring.

### DIFF
--- a/lib/activerecord-import/active_record/adapters/jdbcmysql_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/jdbcmysql_adapter.rb
@@ -2,5 +2,5 @@ require "active_record/connection_adapters/mysql_adapter"
 require "activerecord-import/adapters/mysql_adapter"
 
 class ActiveRecord::ConnectionAdapters::MysqlAdapter
-  include ActiveRecord::Import::MysqlAdapter::InstanceMethods
+  include ActiveRecord::Import::MysqlAdapter
 end


### PR DESCRIPTION
A simple clean-up to get rid of the dependency on InstanceMethods...
