### PR TITLE
Model#import fails to find model's primary key sequence

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -297,7 +297,7 @@ class ActiveRecord::Base
       array_of_attributes.map do |arr|
         my_values = arr.each_with_index.map do |val,j|
           column = columns[j]
-          if !sequence_name.blank? && column.name == primary_key && val.nil?
+          if val.nil? && !sequence_name.blank? && column.name == primary_key
              connection.next_value_for_sequence(sequence_name)
           else
             connection.quote(column.type_cast(val), column)

--- a/test/postgresql/import_test.rb
+++ b/test/postgresql/import_test.rb
@@ -17,4 +17,9 @@ describe "#import" do
       assert_equal 1, result.num_inserts
     end
   end
+  
+  it "should import models whose primary key has no sequence if the primary key's value is specified" do
+    result = Widget.import Build(3, :widgets)
+    assert_equal 1, result.num_inserts
+  end
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -95,4 +95,8 @@ ActiveRecord::Schema.define do
   end
   
   add_index :animals, [:name], :unique => true, :name => 'uk_animals'
+
+  create_table :widgets, :id => false, :force => true do |t|
+    t.integer :w_id
+  end
 end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -11,3 +11,7 @@ Factory.define :topic do |m|
   m.sequence(:title){ |n| "Title #{n}"}
   m.sequence(:author_name){ |n| "Author #{n}"}
 end
+
+Factory.define :widget do |m|
+  m.sequence(:w_id){ |n| n}
+end


### PR DESCRIPTION
Fixes a bug where Model#import does not work when a model's primary key
has no associated 'sequence' in the database. If a value for the primary
key is specified, then the insert should not require a database
'sequence' to generate a value for that primary key field.

I've included a test for postgres.
