### PR TITLE
Raise a useful message when passing validate: false and a value doesn't have a corresponding column

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -17,6 +17,12 @@ module ActiveRecord::Import #:nodoc:
       true
     end
   end
+
+  class MissingColumnError < StandardError
+    def initialize(index)
+      super "Missing column for value at index #{index}"
+    end
+  end
 end
 
 class ActiveRecord::Base
@@ -297,6 +303,9 @@ class ActiveRecord::Base
       array_of_attributes.map do |arr|
         my_values = arr.each_with_index.map do |val,j|
           column = columns[j]
+
+          raise ActiveRecord::Import::MissingColumnError.new(j) if column.nil?
+
           if val.nil? && !sequence_name.blank? && column.name == primary_key
              connection.next_value_for_sequence(sequence_name)
           else

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -46,6 +46,12 @@ describe "#import" do
           result = Topic.import columns, invalid_values, :validate => false
         end
       end
+
+      it 'should raise a specific error if a column does not exist' do
+        assert_raises ActiveRecord::Import::MissingColumnError do
+          Topic.import ['foo'], [['bar']], :validate => false
+        end
+      end
     end
   
     context "with validation checks turned on" do


### PR DESCRIPTION
This results in a more friendly and useful error message than:

```
NoMethodError: undefined method `type_cast' for nil:NilClass
```

And is specific to the case where `validate: false` is passed as ActiveRecord would otherwise raise the error:

```
NoMethodError: undefined method `foo=' for #<Topic:0x007fd26e5238c8>
```
