### PR TITLE
import should be scope-aware

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -276,6 +276,13 @@ class ActiveRecord::Base
     # information on +column_names+, +array_of_attributes_ and
     # +options+.
     def import_without_validations_or_callbacks( column_names, array_of_attributes, options={} )
+      scope_columns, scope_values = scope_attributes.to_a.transpose
+
+      unless scope_columns.blank?
+        column_names.concat scope_columns
+        array_of_attributes.each { |a| a.concat scope_values }
+      end
+
       columns = column_names.each_with_index.map do |name, i|
         column = columns_hash[name.to_s]
 

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -293,4 +293,18 @@ describe "#import" do
       assert_equal "2010/05/14".to_date, Topic.last.last_read.to_date
     end
   end
+
+  context "importing through an association scope" do
+    [ true, false ].each do |b|
+      context "when validation is " + (b ? "enabled" : "disabled") do
+        it "should automatically set the foreign key column" do
+          books = [[ "David Chelimsky", "The RSpec Book" ], [ "Chad Fowler", "Rails Recipes" ]]
+          topic = Factory.create :topic
+          topic.books.import [ :author_name, :title ], books, :validate => b
+          assert_equal 2, topic.books.count
+          assert topic.books.all? { |b| b.topic_id == topic.id }
+        end
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,3 +44,8 @@ adapter_schema = test_dir.join("schema/#{adapter}_schema.rb")
 require adapter_schema if File.exists?(adapter_schema)
 
 Dir[File.dirname(__FILE__) + "/models/*.rb"].each{ |file| require file }
+
+# Prevent this deprecation warning from breaking the tests.
+module Rake::DeprecatedObjectDSL
+  remove_method :import
+end


### PR DESCRIPTION
I was kinda expecting the following to automatically set `company_id` by using the association's scope but the column was simply left out. It shouldn't be difficult to do but I'm afraid it's not a priority for me.

``` ruby
class Company < ActiveRecord::Base
  has_many :employees
end

class Employee < ActiveRecord::Base
  belongs_to :company
end

Company.create.employees.import [ :name ], [ ["Jim"], ["Bob"], ["Fred"] ]
```
