### PR TITLE
Fix case-sensitive SQLite3 adapter name typos.

### DIFF
--- a/lib/activerecord-import/active_record/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/sqlite3_adapter.rb
@@ -1,7 +1,7 @@
 require "active_record/connection_adapters/sqlite3_adapter"
 require "activerecord-import/adapters/sqlite3_adapter"
 
-class ActiveRecord::ConnectionAdapters::Sqlite3Adapter
-  include ActiveRecord::Import::Sqlite3Adapter
+class ActiveRecord::ConnectionAdapters::SQLite3Adapter
+  include ActiveRecord::Import::SQLite3Adapter
 end
 

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -1,4 +1,4 @@
-module ActiveRecord::Import::Sqlite3Adapter
+module ActiveRecord::Import::SQLite3Adapter
   def next_value_for_sequence(sequence_name)
     %{nextval('#{sequence_name}')}
   end

--- a/test/active_record/connection_adapter_test.rb
+++ b/test/active_record/connection_adapter_test.rb
@@ -50,3 +50,13 @@ describe "ActiveRecord::ConnectionAdapter::AbstractAdapter" do
   end
   
 end
+
+describe "ActiveRecord::Import DB-specific adapter class" do
+  context "when ActiveRecord::Import is in use" do
+    it "should appear in the AR connection adapter class's ancestors" do
+      connection = ActiveRecord::Base.connection
+      import_class_name = 'ActiveRecord::Import::' + connection.class.name.demodulize
+      assert_include connection.class.ancestors, import_class_name.constantize
+    end
+  end
+end


### PR DESCRIPTION
The SQLite3 adapter name was referenced as `ActiveRecord::ConnectionAdapters::Sqlite3Adapter`, but the ActiveRecord class is spelled `SQLite3Adapter` (upper-case "SQL"). As a result, `active_record/adapters/sqlite3_adapter.rb` wasn't actually including the methods from `adapters/sqlite3_adapter.rb` into the AR adapter class.

This adds an inheritance test and fixes the spelling of `SQLite3Adapter`, unifying all references to the ActiveRecord version.

I ran into this because I was looking at implementing "on duplicate key update" support for SQLite, and couldn't figure out why none of my ARImport SQLite3 adapter methods were coming through on `ActiveRecord::Base.connection`.
