### PR TITLE
bugfix in sqlite3 adapter

### DIFF
--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -3,9 +3,10 @@ module ActiveRecord::Import::SQLite3Adapter
 
   # Override our conformance to ActiveRecord::Import::ImportSupport interface
   # to ensure that we only support import in supported version of SQLite.
-  # Which INSERT statements with multiple value sets was introduced in 3.2.11.
+  # According to http://www.sqlite.org/changes.html  which INSERT statements with multiple value sets was introduced in 3.7.11.
+
   def supports_import?(current_version=self.sqlite_version)
-    minimum_supported_version = "3.2.11"
+    minimum_supported_version = "3.7.11"
     if current_version >= minimum_supported_version
       true
     else

--- a/test/sqlite3/import_test.rb
+++ b/test/sqlite3/import_test.rb
@@ -1,32 +1,32 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 describe "#supports_imports?" do
-  context "and SQLite is 3.2.11 or higher" do
+  context "and SQLite is 3.7.11 or higher" do
     it "supports import" do
-      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.2.11")
+      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.7.11")
       assert ActiveRecord::Base.supports_import?(version)
 
-      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.2.12")
+      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.7.12")
       assert ActiveRecord::Base.supports_import?(version)
     end
   end
 
-  context "and SQLite less than 3.2.11" do
+  context "and SQLite less than 3.7.11" do
     it "doesn't support import" do
-      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.2.10")
+      version = ActiveRecord::ConnectionAdapters::SQLiteAdapter::Version.new("3.7.10")
       assert !ActiveRecord::Base.supports_import?(version)
     end
   end
 end
 
 describe "#import" do
-  it "import with a single insert on SQLite 3.2.11 or higher" do
+  it "import with a single insert on SQLite 3.7.11 or higher" do
     assert_difference "Topic.count", +10 do
       result = Topic.import Build(3, :topics)
-      assert_equal 1, result.num_inserts, "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.2.11 or higher) installed"
+      assert_equal 1, result.num_inserts, "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
 
       result = Topic.import Build(7, :topics)
-      assert_equal 1, result.num_inserts, , "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.2.11 or higher) installed"
+      assert_equal 1, result.num_inserts, , "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
     end
   end
 end


### PR DESCRIPTION
INSERT syntax to allow multiple rows to be inserted via the VALUES clause was enhanced from 3.7.11

http://www.sqlite.org/changes.html

current master declares that it is 3.2.11 and thats why import always throws exception about syntax error.
