### PR TITLE
adds #ar_import alias_method

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -230,6 +230,7 @@ class ActiveRecord::Base
       return_obj.num_inserts = 0 if return_obj.num_inserts.nil?
       return_obj
     end
+    alias_method :ar_import, :import
     
     # TODO import_from_table needs to be implemented. 
     def import_from_table( options ) # :nodoc:

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -347,3 +347,9 @@ describe "#import" do
   end
 
 end
+
+describe '#ar_import' do
+  it 'aliases to #import' do
+    assert_equal(ActiveRecord::Base.method(:ar_import), ActiveRecord::Base.method(:import))
+  end
+end


### PR DESCRIPTION
Hi,

We encountered an issue where the `::import` method you have defined in your library was getting overridden by `Tire::import` method. Adding the `alias_method` resolves the problem. I'm glad to change the name of the alias if you do not like it.


Thanks,
skim