### PR TITLE
No longer modify input array; deep clone it first

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -200,7 +200,7 @@ class ActiveRecord::Base
       end
 
       # dup the passed in array so we don't modify it unintentionally
-      array_of_attributes = array_of_attributes.dup
+      array_of_attributes = array_of_attributes.map(&:dup)
 
       # Force the primary key col into the insert if it's not
       # on the list and we are using a sequence and stuff a nil


### PR DESCRIPTION
This pull request resolves issue #22.

If you call #import with an array of values, activerecord-import will currently modify that array with updated_at and created_at timestamps for each row. This change prevents the array you pass in from being modified.