### PR TITLE
Optionally disable ON DUPLICATE KEY UPDATE

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -142,7 +142,7 @@ class ActiveRecord::Base
     #
     # == On Duplicate Key Update (MySQL only)
     #
-    # The :on_duplicate_key_update option can be either an Array or a Hash. 
+    # The :on_duplicate_key_update option can be either an Array or a Hash, or `false` to disable ON DUPLICATE KEY UPDATE completely. 
     # 
     # ==== Using an Array
     #
@@ -372,7 +372,7 @@ class ActiveRecord::Base
             if options[:on_duplicate_key_update]
               options[:on_duplicate_key_update] << key.to_sym if options[:on_duplicate_key_update].is_a?(Array)
               options[:on_duplicate_key_update][key.to_sym] = key.to_sym if options[:on_duplicate_key_update].is_a?(Hash)
-            else
+            elsif options[:on_duplicate_key_update] != false
               options[:on_duplicate_key_update] = [ key.to_sym ]
             end
           end


### PR DESCRIPTION
For MySQL, it would be nice if the ON DUPLICATE KEY UPDATE option could be disabled completely, by passing `:on_duplicate_key_update => false`. 

Unfortunately I have no idea how to write a test for this small modification that uses your conventions; I have verified that it doesn't break any existing tests (for mysql2), and that it indeed drops the ON DUP... clause from the INSERT statement.

Many thanks for the great gem!