### PR TITLE
Add support for em_mysql2 adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   platforms :ruby do
     gem "mysql", "~> 2.8.1"
     gem "mysql2", "~> 0.3.0"
+    gem 'em-synchrony', "~> 1.0.3"
     gem "pg", "~> 0.9"
     gem "sqlite3-ruby", "~> 1.3.1"
     gem "seamless_database_pool", "~> 1.0.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,9 @@ GEM
     debugger-ruby_core_source (1.1.3)
     delorean (0.2.1)
       chronic
+    em-synchrony (1.0.3)
+      eventmachine (>= 1.0.0.beta.1)
+    eventmachine (1.0.3)
     factory_girl (1.3.3)
     git (1.2.5)
     i18n (0.6.0)
@@ -72,6 +75,7 @@ DEPENDENCIES
   activerecord-jdbcmysql-adapter
   debugger
   delorean (~> 0.2.0)
+  em-synchrony (~> 1.0.3)
   factory_girl (~> 1.3.3)
   jdbc-mysql
   jeweler (>= 1.4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ namespace :display do
 end
 task :default => ["display:notice"]
 
-ADAPTERS = %w(mysql mysql2 jdbcmysql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
+ADAPTERS = %w(mysql mysql2 em_mysql2 jdbcmysql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
 ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."

--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
     "lib/activerecord-import.rb",
     "lib/activerecord-import/active_record/adapters/abstract_adapter.rb",
     "lib/activerecord-import/active_record/adapters/jdbcmysql_adapter.rb",
+    "lib/activerecord-import/active_record/adapters/em_mysql2_adapter.rb",
     "lib/activerecord-import/active_record/adapters/mysql2_adapter.rb",
     "lib/activerecord-import/active_record/adapters/mysql_adapter.rb",
     "lib/activerecord-import/active_record/adapters/postgresql_adapter.rb",
@@ -35,6 +36,7 @@ Gem::Specification.new do |s|
     "lib/activerecord-import/import.rb",
     "lib/activerecord-import/mysql.rb",
     "lib/activerecord-import/mysql2.rb",
+    "lib/activerecord-import/em_mysql2.rb",
     "lib/activerecord-import/postgresql.rb",
     "lib/activerecord-import/sqlite3.rb",
     "lib/activerecord-import/synchronize.rb"

--- a/lib/activerecord-import/active_record/adapters/em_mysql2_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/em_mysql2_adapter.rb
@@ -1,0 +1,8 @@
+require "em-synchrony"
+require "em-synchrony/mysql2"
+require "em-synchrony/activerecord"
+require "activerecord-import/adapters/em_mysql2_adapter"
+
+class ActiveRecord::ConnectionAdapters::EMMysql2Adapter
+  include ActiveRecord::Import::EMMysql2Adapter
+end

--- a/lib/activerecord-import/adapters/em_mysql2_adapter.rb
+++ b/lib/activerecord-import/adapters/em_mysql2_adapter.rb
@@ -1,0 +1,5 @@
+require File.dirname(__FILE__) + "/mysql_adapter"
+
+module ActiveRecord::Import::EMMysql2Adapter
+  include ActiveRecord::Import::MysqlAdapter
+end

--- a/lib/activerecord-import/em_mysql2.rb
+++ b/lib/activerecord-import/em_mysql2.rb
@@ -1,0 +1,7 @@
+warn <<-MSG
+[DEPRECATION] loading activerecord-import via 'require "activerecord-import/<adapter-name>"'
+  is deprecated. Update to autorequire using 'require "activerecord-import"'. See
+  http://github.com/zdennis/activerecord-import/wiki/Requiring for more information
+MSG
+
+require File.expand_path(File.join(File.dirname(__FILE__),  "/../activerecord-import"))

--- a/test/adapters/em_mysql2.rb
+++ b/test/adapters/em_mysql2.rb
@@ -1,0 +1,1 @@
+ENV["ARE_DB"] = "em_mysql2"

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -1,6 +1,6 @@
 common: &common
   username: root
-  password: 
+  password:
   encoding: utf8
   host:     localhost
   database: activerecord_import_test
@@ -12,6 +12,11 @@ mysql:
 mysql2:
   <<: *common
   adapter: mysql2
+
+em_mysql2:
+  <<: *common
+  adapter: em_mysql2
+  pool: 5
 
 mysqlspatial:
   <<: *mysql

--- a/test/em_mysql2/import_test.rb
+++ b/test/em_mysql2/import_test.rb
@@ -1,0 +1,6 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
+
+should_support_mysql_import_functionality


### PR DESCRIPTION
Nice work on this gem, it's been very handy over the years!

I've added support for the [em_mysql2](https://github.com/igrigorik/em-synchrony/blob/master/lib/active_record/connection_adapters/em_mysql2_adapter.rb) adapter provided by [em-synchrony](https://github.com/igrigorik/em-synchrony).  I tried to follow the pattern established by the mysql2 adapter as closely as possible, so the em_mysql2 adapter is just a thin wrapper around the mysql adapter.  I'm not an em-synchrony expert by any means, but I didn't think of any reason why it should work differently than mysql/mysql2 for this library.

I've run the tests for mysql, mysql2, postgresql, and em_mysql2.  All of them pass.  I'm running the fork in my (Sinatra w/ ActiveRecord) application and it gives the expected results.

Comments and suggestions welcome.
