### PR TITLE
sqlserver and oracle adapters workaround

### DIFF
--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -11,14 +11,19 @@ module ActiveRecord::Import
     when 'mysql2spatial' then 'mysql2'
     when 'spatialite' then 'sqlite3'
     when 'postgis' then 'postgresql'
+    when 'sqlserver' then ''
+    when 'oracle' then ''
     else adapter
     end
   end
   
   # Loads the import functionality for a specific database adapter
   def self.require_adapter(adapter)
-    require File.join(AdapterPath,"/abstract_adapter")
-    require File.join(AdapterPath,"/#{base_adapter(adapter)}_adapter")
+    base_adapter = base_adapter(adapter)
+    unless base_adapter.blank?
+      require File.join(AdapterPath,"/abstract_adapter")
+      require File.join(AdapterPath,"/#{base_adapter}_adapter")
+    end
   end
 
   # Loads the import functionality for the passed in ActiveRecord connection


### PR DESCRIPTION
Hi. There was an error while trying to establish connection to mssql database. It was looking for mssqlserver adapter which is not supported yet. I have made some fix/workaround and everything works fine. Error doesn't occur any more.