### PR TITLE
fix mysql import error. uninitialized constant.

### DIFF
--- a/lib/activerecord-import/value_sets_parser.rb
+++ b/lib/activerecord-import/value_sets_parser.rb
@@ -1,5 +1,5 @@
 module ActiveRecord::Import
-  class ValuesSetsBytesParser
+  class ValueSetsBytesParser
     attr_reader :reserved_bytes, :max_bytes, :values
 
     def self.parse(values, options)


### PR DESCRIPTION
The following error occurred import in MySQL.
uninitialized constant ActiveRecord::Import::ValueSetsBytesParser
Is it a typo?

Did using only in this file.
https://github.com/zdennis/activerecord-import/blob/27139cfa7902df0af2e9415ec22551e1f111a83e/lib/activerecord-import/adapters/mysql_adapter.rb#L39
