### PR TITLE
documentation for additional adapters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,12 +45,12 @@ If `fake_name` adapter is needed by a gem (potentially called `activerecord-impo
 activerecord-import-fake_name/
 |-- activerecord-import-fake_name.gemspec
 |-- lib
-|   |-- activerecord-import-fake_name
-|   |   |-- version.rb
-|   |-- activerecord-import
-|   |   |-- active_record
-|   |   |   |-- adapters
-|   |   |       |-- fake_name_adapter.rb
+|   |-- activerecord-import-fake_name
+|   |   |-- version.rb
+|   |-- activerecord-import
+|   |   |-- active_record
+|   |   |   |-- adapters
+|   |   |       |-- fake_name_adapter.rb
 |--activerecord-import-fake_name.rb
 ```
 


### PR DESCRIPTION
after the PR yesterday I wanted to provide more detail for other adapter authors to be clear on how the loading is expected to work.  the README may not be the right place, but GH doesn't allow PR's into wiki entries.  This documentation may be helpful to point any authors at how they should define a gem that will work with AR-import
