### PR TITLE
Do not set created_at/on timestamp for existing records

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -348,8 +348,8 @@ class ActiveRecord::Base
         if self.column_names.include?(key)
           value = blk.call
           if index=column_names.index(key)
-             # replace every instance of the array of attributes with our value
-             array_of_attributes.each{ |arr| arr[index] = value }
+            # replace every instance of the array of attributes with our value
+            array_of_attributes.each{ |arr| arr[index] = value if arr[index].nil? }
           else
             column_names << key
             array_of_attributes.each { |arr| arr << value }


### PR DESCRIPTION
When `array_of_attributes` contains the value for `created_at`, `import` overwrites this value with `Time.now`. The expected behavior in Rails is to not overwrite the value if it's being passed in. The way I discovered this was I was passing in `WidgetModel#attributes` to the import method, and I observed the `created_at` values in the DB were being overwritten. 
