### PR TITLE
Add makara database adapter

### DIFF
--- a/lib/activerecord-import/adapters/mysql2_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql2_adapter.rb
@@ -1,4 +1,4 @@
-require "activerecord-import/adapters/mysql_adapter"
+require File.dirname(__FILE__) + "/mysql_adapter"
 
 module ActiveRecord::Import::Mysql2Adapter
   include ActiveRecord::Import::MysqlAdapter


### PR DESCRIPTION
This makes activerecord-import compatible with the makara gem.  Thanks @cmthakur for the suggestion -- filename in your version was slightly off from newest version of makara.