### PR TITLE
Only add columns that haven't already been added

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -370,7 +370,7 @@ class ActiveRecord::Base
 
           if supports_on_duplicate_key_update?
             if options[:on_duplicate_key_update]
-              options[:on_duplicate_key_update] << key.to_sym if options[:on_duplicate_key_update].is_a?(Array)
+              options[:on_duplicate_key_update] << key.to_sym if options[:on_duplicate_key_update].is_a?(Array) && !options[:on_duplicate_key_update].include?(key.to_sym)
               options[:on_duplicate_key_update][key.to_sym] = key.to_sym if options[:on_duplicate_key_update].is_a?(Hash)
             else
               options[:on_duplicate_key_update] = [ key.to_sym ]


### PR DESCRIPTION
This fixes issues #35, #77, and #126.

Although not actually harming anything or having any functional effect, this bug was making queries significantly longer than they needed to be.
