### PR TITLE
add jdbcpostgresql support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,9 @@ end
 
 platforms :jruby do
   gem "jdbc-mysql"
+  gem "jdbc-postgres"
   gem "activerecord-jdbcmysql-adapter"
+  gem "activerecord-jdbcpostgresql-adapter"
 end
 
 # Support libs

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :display do
 end
 task :default => ["display:notice"]
 
-ADAPTERS = %w(mysql mysql2 em_mysql2 jdbcmysql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
+ADAPTERS = %w(mysql mysql2 em_mysql2 jdbcmysql jdbcpostgresql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
 ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."

--- a/lib/activerecord-import/active_record/adapters/jdbcpostgresql_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/jdbcpostgresql_adapter.rb
@@ -1,0 +1,6 @@
+require "active_record/connection_adapters/postgresql_adapter"
+require "activerecord-import/adapters/postgresql_adapter"
+
+class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  include ActiveRecord::Import::PostgreSQLAdapter
+end

--- a/test/adapters/jdbcpostgresql.rb
+++ b/test/adapters/jdbcpostgresql.rb
@@ -1,0 +1,1 @@
+ENV["ARE_DB"] = "jdbcpostgresql"

--- a/test/jdbcpostgresql/import_test.rb
+++ b/test/jdbcpostgresql/import_test.rb
@@ -1,0 +1,6 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+#require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
+
+should_support_postgresql_import_functionality


### PR DESCRIPTION
Added jdbcpostgresql support by cloning the jdbcmysql setup.

```
[10:43:07] huned@snitch:activerecord-import $ bundle exec rake test:jdbcpostgresql
Your Gemfile lists the gem ruby-debug (= 0.10.4) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
file:/Users/huned/.rbenv/versions/jruby-9000-dev/lib/jruby.jar!/jruby/kernel/kernel.rb:25 warning: unsupported exec option: close_others
-- create_table(:schema_info, {:force=>true})
   -> 0.1240s
-- create_table(:group, {:force=>true})
   -> 0.0060s
-- create_table(:topics, {:force=>true})
   -> 0.0080s
-- create_table(:projects, {:force=>true})
   -> 0.0070s
-- create_table(:developers, {:force=>true})
   -> 0.0060s
-- create_table(:addresses, {:force=>true})
   -> 0.0070s
-- create_table(:teams, {:force=>true})
   -> 0.0060s
-- create_table(:books, {:force=>true})
   -> 0.0090s
-- create_table(:languages, {:force=>true})
   -> 0.0060s
-- create_table(:shopping_carts, {:force=>true})
   -> 0.0060s
-- create_table(:cart_items, {:force=>true})
   -> 0.0060s
-- add_index(:cart_items, [:shopping_cart_id, :book_id], {:unique=>true, :name=>"uk_shopping_cart_books"})
   -> 0.0080s
   -> 0 rows
-- create_table(:animals, {:force=>true})
   -> 0.0070s
-- add_index(:animals, [:name], {:unique=>true, :name=>"uk_animals"})
   -> 0.0040s
   -> 0 rows
-- create_table(:widgets, {:id=>false, :force=>true})
   -> 0.0050s
Run options: 

# Running tests:

.................[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
...........................................

Finished tests in 0.933000s, 64.3087 tests/s, 144.6945 assertions/s.

60 tests, 135 assertions, 0 failures, 0 errors, 0 skips

ruby -v: jruby 9000.dev (2.1.0.dev) 2014-03-05 f8f16cc on Java HotSpot(TM) 64-Bit Server VM 1.7.0_51-b13 [darwin-x86_64]
[10:43:35] huned@snitch:activerecord-import $ 
```
