### PR TITLE
Fix "ruby-debug" listed more than once "warning"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,13 +23,12 @@ gem "factory_girl", "~> 4.2.0"
 gem "delorean",     "~> 0.2.0"
 
 # Debugging
-platforms :mri_18 do
-  gem "ruby-debug", "= 0.10.4"
-end
-
 platforms :jruby do
   gem "ruby-debug-base", "= 0.10.4"
-  gem "ruby-debug",      "= 0.10.4"
+end
+
+platforms :jruby, :mri_18 do
+  gem "ruby-debug", "= 0.10.4"
 end
 
 platforms :mri_19 do


### PR DESCRIPTION
Move "ruby-debug" to a common "platform" section to fix the warning about it being listed multiple times (during "bundle").

```
Your Gemfile lists the gem ruby-debug (= 0.10.4) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```
