### PR TITLE
Set "object_ids" during import

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -1,5 +1,9 @@
 module ActiveRecord::Import::AbstractAdapter
   module InstanceMethods
+    def increment_sequence_and_get_next_id(sequence_name, increment_by)
+      raise NotImplementedError
+    end
+
     def next_value_for_sequence(sequence_name)
       %{#{sequence_name}.nextval}
     end

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -1,6 +1,23 @@
 module ActiveRecord::Import::PostgreSQLAdapter
   include ActiveRecord::Import::ImportSupport
 
+  def increment_sequence_and_get_next_id(sequence_name, increment_by)
+    result = execute(<<-SQL
+    select
+      nextval('#{sequence_name}') as next_id,
+      setval(
+        '#{sequence_name}',
+        currval('#{sequence_name}'
+      ) + #{increment_by - 1}) as next_available_id
+    SQL
+    ).first
+    if result && next_id = result['next_id']
+      next_id.to_i
+    else
+      raise %{Could not update sequence: "#{sequence_name}"}
+    end
+  end
+
   def next_value_for_sequence(sequence_name)
     %{nextval('#{sequence_name}')}
   end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -181,13 +181,35 @@ class ActiveRecord::Base
           column_names = self.column_names.dup
         end
 
+        # skip this block unless hydrating "object_ids" (this feature assumes
+        # simple primary/foreign key relationships)
+        if hydrate_object_ids = options.delete(:hydrate_object_ids)
+          model_class = models.first.class
+          primary_key_attribute = model_class.primary_key
+          foreign_key_attribute = "#{model_class.name.downcase}_#{primary_key_attribute}"
+          associations = model_class.reflect_on_all_associations.map(&:name)
+          next_id = connection.increment_sequence_and_get_next_id(sequence_name, models.count)
+        end
+
         array_of_attributes = models.map do |model|
-          # this next line breaks sqlite.so with a segmentation fault
-          # if model.new_record? || options[:on_duplicate_key_update]
-            column_names.map do |name|
-              model.send( "#{name}_before_type_cast" )
+          # the following block will set the "primary" and "foreign" key values
+          # to the "next_id" value from the top level model's sequence (only if
+          # the current value is "nil"). If for some reason a record fails to
+          # save, depending on the adapter, may result in a gap in the "primary"
+          # key values for the backing table
+          if hydrate_object_ids && model[primary_key_attribute].nil?
+            model[primary_key_attribute] = next_id
+            associations.each do |association|
+              [model.send(association)].flatten.compact.each do |associated_model|
+                if associated_model.respond_to?(foreign_key_attribute) && associated_model[foreign_key_attribute].nil?
+                  associated_model[foreign_key_attribute] = next_id
+                end
+              end
             end
-          # end
+            next_id += 1
+          end
+          # return an array of the model instance's attribute values
+          column_names.map { |name| model.send("#{name}_before_type_cast") }
         end
         # supports empty array
       elsif args.last.is_a?( Array ) and args.last.empty?

--- a/test/postgresql/import_test.rb
+++ b/test/postgresql/import_test.rb
@@ -2,3 +2,26 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
 
 should_support_postgresql_import_functionality
+
+describe '.import' do
+  context 'with: hydrate_object_ids' do
+    let(:options) { { :hydrate_object_ids => true } }
+    let(:topics) { FactoryGirl.build_list(:topic_with_books, 3) }
+    let(:books) { topics.collect(&:books).flatten.compact }
+
+    setup do
+      Topic.import topics, options
+      Book.import books, options
+    end
+
+    it 'should set the primary key values into the model references' do
+      assert topics.count > 0
+      assert topics.all?(&:id)
+    end
+
+    it 'should set the foreign key values into the model references' do
+      assert books.count > 0
+      assert books.all?(&:topic_id)
+    end
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -1,19 +1,26 @@
 FactoryGirl.define do
+  factory :book do
+    sequence(:title) { |n| "Title #{n}" }
+    sequence(:publisher) { |n| "Publisher #{n}" }
+    sequence(:author_name) { |n| "Author #{n}" }
+  end
+
   factory :group do
     sequence(:order) { |n| "Order #{n}" }
   end
 
-  factory :invalid_topic, :class => "Topic" do
-    sequence(:title){ |n| "Title #{n}"}
-    author_name nil
-  end
-
   factory :topic do
-    sequence(:title){ |n| "Title #{n}"}
-    sequence(:author_name){ |n| "Author #{n}"}
+    sequence(:title) { |n| "Title #{n}" }
+    sequence(:author_name) { |n| "Author #{n}" }
+    factory :invalid_topic do
+      author_name nil
+    end
+    factory :topic_with_books do
+      books { build_list(:book, 3) }
+    end
   end
 
   factory :widget do
-    sequence(:w_id){ |n| n}
+    sequence(:w_id) { |n| n }
   end
 end


### PR DESCRIPTION
If enabled (via "hydrate_object_ids"), set the "primary" and "foreign"
key values on the model objects passed into the "import" method. This
functionality was added in an attempt to make it easier to import graphs
of objects. This functionality only exists for the "PostgreSQL Adapter"