### PR TITLE
Allow for `:on_duplicate_key_update` to be turned off

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -368,7 +368,7 @@ class ActiveRecord::Base
             array_of_attributes.each { |arr| arr << value }
           end
 
-          if supports_on_duplicate_key_update?
+          if supports_on_duplicate_key_update? and options[:on_duplicate_key_update] != false
             if options[:on_duplicate_key_update]
               options[:on_duplicate_key_update] << key.to_sym if options[:on_duplicate_key_update].is_a?(Array) && !options[:on_duplicate_key_update].include?(key.to_sym)
               options[:on_duplicate_key_update][key.to_sym] = key.to_sym if options[:on_duplicate_key_update].is_a?(Hash)

--- a/test/support/mysql/assertions.rb
+++ b/test/support/mysql/assertions.rb
@@ -39,10 +39,13 @@ class ActiveSupport::TestCase
           assert_equal "johndoe@example.com", updated_topic.author_email_address
         end
 
-        assertion(:should_not_update_fields_mentioned) do
-          perform_import
-          assert_equal "Book - 2nd Edition", updated_topic.title
-          assert_equal "johndoe@example.com", updated_topic.author_email_address
+        assertion(:should_raise_update_fields_mentioned) do
+          assert_raise ActiveRecord::RecordNotUnique do 
+            perform_import
+          end
+          
+          assert_equal "Book", updated_topic.title
+          assert_equal "john@doe.com", updated_topic.author_email_address
         end
 
         assertion(:should_update_fields_mentioned_with_hash_mappings) do

--- a/test/support/mysql/assertions.rb
+++ b/test/support/mysql/assertions.rb
@@ -39,6 +39,12 @@ class ActiveSupport::TestCase
           assert_equal "johndoe@example.com", updated_topic.author_email_address
         end
 
+        assertion(:should_not_update_fields_mentioned) do
+          perform_import
+          assert_equal "Book - 2nd Edition", updated_topic.title
+          assert_equal "johndoe@example.com", updated_topic.author_email_address
+        end
+
         assertion(:should_update_fields_mentioned_with_hash_mappings) do
           perform_import
           assert_equal "johndoe@example.com", updated_topic.title

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -118,22 +118,23 @@ def should_support_mysql_import_functionality
     end
   
     context "given array of model instances with :on_duplicate_key_update turned off" do
+      let(:columns){  %w( id title author_name author_email_address parent_id ) }
+      let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com", 17 ] ] }
+      let(:updated_values){ [ [ 100, "Book - 2nd Edition", "This should raise an exception", "john@nogo.com", 57 ] ] }
+
       macro(:perform_import) do |*opts|
-        @topic.title = "Book - 2nd Edition"
-        @topic.author_name = "Author Should Not Change"
-        @topic.author_email_address = "johndoe@example.com"
-        @topic.parent_id = 57
-        Topic.import [@topic], opts.extract_options!.merge(:on_duplicate_key_update => false, :validate => false)
+        # `:on_duplicate_key_update => false` is the tested feature
+        Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => false, :validate => false)
       end
 
       setup do
-        @topic = Generate(:topic, :id => 99, :author_name => "John Doe", :parent_id => 17)
+        Topic.import columns, values, :validate => false
+        @topic = Topic.find 100
       end
     
       context "using string column names" do
         let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
-        should_support_on_duplicate_key_update
-        should_not_update_fields_mentioned
+        should_raise_update_fields_mentioned
       end
     end
   end

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -116,7 +116,26 @@ def should_support_mysql_import_functionality
         should_update_fields_mentioned_with_hash_mappings
       end
     end
+  
+    context "given array of model instances with :on_duplicate_key_update turned off" do
+      macro(:perform_import) do |*opts|
+        @topic.title = "Book - 2nd Edition"
+        @topic.author_name = "Author Should Not Change"
+        @topic.author_email_address = "johndoe@example.com"
+        @topic.parent_id = 57
+        Topic.import [@topic], opts.extract_options!.merge(:on_duplicate_key_update => false, :validate => false)
+      end
 
+      setup do
+        @topic = Generate(:topic, :id => 99, :author_name => "John Doe", :parent_id => 17)
+      end
+    
+      context "using string column names" do
+        let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
+        should_support_on_duplicate_key_update
+        should_not_update_fields_mentioned
+      end
+    end
   end
 
   describe "#import with :synchronization option" do


### PR DESCRIPTION
There is currently no option to tell the MySQL importer to fail on duplicate entries. I added this support locally for rails 3 and decided to PR this feature back for the master fork. Now if you explicitly set `:on_duplicate_key_update => false` in the import options it won't allow for duplicate keys to update existing elements. This was important for an application where all the data being imported should be new rows and any duplicates indicates an error in the input data.

It would be nice if there was a way to create a new branch/release for rails 3 to get updates that the rails 4 master branch is receiving (so I can reference your master fork instead of the PR fork).