### PR TITLE
Prequote timestamps for a speed boost

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -412,7 +412,7 @@ class ActiveRecord::Base
     def add_special_rails_stamps( column_names, array_of_attributes, options )
       AREXT_RAILS_COLUMNS[:create].each_pair do |key, blk|
         if self.column_names.include?(key)
-          value = blk.call
+          value = connection.quote blk.call
           if index=column_names.index(key) || index=column_names.index(key.to_sym)
             # replace every instance of the array of attributes with our value
             array_of_attributes.each{ |arr| arr[index] = value if arr[index].nil? }
@@ -425,7 +425,7 @@ class ActiveRecord::Base
 
       AREXT_RAILS_COLUMNS[:update].each_pair do |key, blk|
         if self.column_names.include?(key)
-          value = blk.call
+          value = connection.quote blk.call
           if index=column_names.index(key) || index=column_names.index(key.to_sym)
              # replace every instance of the array of attributes with our value
              array_of_attributes.each{ |arr| arr[index] = value }


### PR DESCRIPTION
I did some profiling and found that a lot of time is spent quoting the timestamps for every single row, even though the result is the same each time. We can prevent this from happening by quoting them beforehand instead. This gave me about a 5% speed boost.