### PR TITLE
Handle primary_key array (compositive_foreign_key)

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -205,9 +205,10 @@ class ActiveRecord::Base
       # Force the primary key col into the insert if it's not
       # on the list and we are using a sequence and stuff a nil
       # value for it into each row so the sequencer will fire later
-      if !column_names.include?(primary_key) && connection.prefetch_primary_key? && sequence_name
-         column_names << primary_key
-         array_of_attributes.each { |a| a << nil }
+      if ![primary_key].flatten.*.to_sym.to_set.subset?(column_names.*.to_sym.to_set) &&
+          sequence_name && connection.prefetch_primary_key?
+        column_names << primary_key
+        array_of_attributes.each { |a| a << nil }
       end
 
       # record timestamps unless disabled in ActiveRecord::Base


### PR DESCRIPTION
Ripped from an old Lighthouse ticket: http://zdennis.lighthouseapp.com/projects/14379/tickets/30-patch-to-support-importing-tables-with-composite-primary-keys

I'll do some further testing and try to add a test case for this when I get a chance. Putting it out there for now for discussion.

This may fix #111.
