### PR TITLE
Sum array explicitly to avoid ActiveSupport bug

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Import::MysqlAdapter
   NO_MAX_PACKET = 0
   QUERY_OVERHEAD = 8 #This was shown to be true for MySQL, but it's not clear where the overhead is from.
 
-  # +sql+ can be a single string or an array. If it is an array all 
+  # +sql+ can be a single string or an array. If it is an array all
   # elements that are in position >= 1 will be appended to the final SQL.
   def insert_many( sql, values, *args ) # :nodoc:
     # the number of inserts default
@@ -20,7 +20,7 @@ module ActiveRecord::Import::MysqlAdapter
     sql_size = QUERY_OVERHEAD + base_sql.size + post_sql.size
 
     # the number of bytes the requested insert statement values will take up
-    values_in_bytes = values.sum {|value| value.bytesize }
+    values_in_bytes = values.map{|value| value.bytesize }.sum
 
     # the number of bytes (commas) it will take to comma separate our values
     comma_separated_bytes = values.size-1

--- a/test/value_sets_bytes_parser_test.rb
+++ b/test/value_sets_bytes_parser_test.rb
@@ -56,7 +56,7 @@ describe ActiveRecord::Import::ValueSetsBytesParser do
         "('4','5','6')",
         "('7','8','9')" ]
 
-      values_size_in_bytes = values.sum {|value| value.bytesize }
+      values_size_in_bytes = values.map {|value| value.bytesize }.sum
       base_sql_size_in_bytes = 15
       max_bytes = 30
 
@@ -84,7 +84,7 @@ describe ActiveRecord::Import::ValueSetsBytesParser do
         base_sql_size_in_bytes = 15
         max_bytes = 26
 
-        values_size_in_bytes = values.sum {|value| value.bytesize }
+        values_size_in_bytes = values.map {|value| value.bytesize }.sum
         value_sets = parser.parse values, reserved_bytes: base_sql_size_in_bytes, max_bytes: max_bytes
 
         assert_equal 2, value_sets.size, 'Two value sets were expected!'


### PR DESCRIPTION
In activesupport (4.1.4), there's a regression in Array#sum
```
[1] pry(main)> ['a', 'b'].sum { |x| x.bytesize }
=> "ab"
[2] pry(main)> ['a', 'b'].map { |x| x.bytesize }.sum
=> 2
```

This commit is a workaround.