### PR TITLE
Rails drops serialized_attributes, so should activerecord-import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -332,8 +332,8 @@ class ActiveRecord::Base
           if val.nil? && column.name == primary_key && !sequence_name.blank?
              connection_memo.next_value_for_sequence(sequence_name)
           else
-            if serialized_attributes.include?(column.name)
-              connection_memo.quote(serialized_attributes[column.name].dump(val), column)
+            if column_for_attribute(column.name)
+              connection_memo.quote(column_for_attribute(column.name).type_cast_for_database(val), column)
             else
               connection_memo.quote(val, column)
             end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/15704/files and the tons of warnings generated when running against Rails 4.2.0.beta1 :smile:
