### PR TITLE
Use read_attribute_before_type_cast instead of #{name}_before_type_cast and allow enums to work

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -251,7 +251,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              model[name].value_before_type_cast
+              model.read_attribute_before_type_cast(name)
             end
           # end
         end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -251,7 +251,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              model.send( "#{name}_before_type_cast" )
+              model[name].value_before_type_cast
             end
           # end
         end


### PR DESCRIPTION
The Rails 4.1 enum library overrides the #{name}_before_type_cast methods so that they return strings that cannot be inserted into the integer columns.  By making this change, the override is avoided and the code reads better anyway.

Addresses issue: https://github.com/zdennis/activerecord-import/issues/139