### PR TITLE
Ensure @attribute_cache is cleared in Rails4.0 or lower

### DIFF
--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -45,9 +45,10 @@ module ActiveRecord # :nodoc:
           instance.instance_variable_set :@attributes, matched_instance.instance_variable_get(:@attributes)
 
           if instance.respond_to?(:clear_changes_information)
-            instance.clear_changes_information                  # Rails 4.1 and higher
+            instance.clear_changes_information                      # Rails 4.1 and higher
           else
-            instance.changed_attributes.clear                   # Rails 3.1, 3.2
+            instance.changed_attributes.clear                       # Rails 3.1, 3.2
+            instance.instance_variable_set '@attributes_cache', {}  # Rails 4.0
           end
 
           # Since the instance now accurately reflects the record in


### PR DESCRIPTION
Backwards compatibility of `synchronize` for Rails4.0 has been broken 
since d18c332c7c35b663012697cbe0060fd60d27a860 was committed.

In Rails4.0, ActiveRecord doesn't have `clear_changes_information` method, 
but clearing `changed_attributes` isn't sufficient to refresh AR object's attribute.
It is necessary to clearing the `@attribute_cache` also.