### PR TITLE
Wrong usage of ActiveSupport.on_load

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -1,10 +1,12 @@
-class ActiveRecord::Base
-  class << self
-    def establish_connection_with_activerecord_import(*args)
-      establish_connection_without_activerecord_import(*args)
-      ActiveSupport.run_load_hooks(:active_record_connection_established, connection_pool)
+ActiveSupport.on_load(:active_record) do
+  class ActiveRecord::Base
+    class << self
+      def establish_connection_with_activerecord_import(*args)
+        establish_connection_without_activerecord_import(*args)
+        ActiveSupport.run_load_hooks(:active_record_connection_established, connection_pool)
+      end
+      alias_method_chain :establish_connection, :activerecord_import
     end
-    alias_method_chain :establish_connection, :activerecord_import
   end
 end
 

--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -2,18 +2,15 @@ ActiveSupport.on_load(:active_record) do
   class ActiveRecord::Base
     class << self
       def establish_connection_with_activerecord_import(*args)
-        establish_connection_without_activerecord_import(*args)
-        ActiveSupport.run_load_hooks(:active_record_connection_established, connection_pool)
+        conn = establish_connection_without_activerecord_import(*args)
+        if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
+          require "activerecord-import/base"
+        end
+
+        ActiveRecord::Import.load_from_connection_pool connection_pool
+        conn
       end
       alias_method_chain :establish_connection, :activerecord_import
     end
   end
-end
-
-ActiveSupport.on_load(:active_record_connection_established) do |connection_pool|
-  if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
-    require "activerecord-import/base"
-  end
-
-  ActiveRecord::Import.load_from_connection_pool connection_pool
 end


### PR DESCRIPTION
activerecord-import is using `ActiveSupport.on_load` in a wrong way.

`ActiveSupport.on_load` is not just a way to add an additional block of code into a Ruby method.
It's a mechanism for adding load hooks which is needed to implement lazy loading in ActiveSupport.

And, in this particular "after_established" case, we don't actually need any special mechanism. Let's just simply call the logic inside the AMC.

This patch is put on top of another PR #136 which I sent last year, because these two PRs are tackling the same sort of problem, and editing the same file. So please just merge this one, then I'll close another one.