### PR TITLE
Relax restrictions on mysql for AR 3.1 and 3.2

### DIFF
--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,4 +1,4 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.8.1'
+  gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.1.0'
 end

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,4 +1,4 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.8.1'
+  gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.2.0'
 end


### PR DESCRIPTION
Allow any version of mysql > 2.8.1 instead of just 2.8.1.  2.8.2 was yanked and 2.8.1 does not seem to build on OS X 10.10