### PR TITLE
em-synchrony 1.0.4 seems to be broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 # Database Adapters
 platforms :ruby do
-  gem "em-synchrony",           "~> 1.0.3"
+  gem "em-synchrony",           "1.0.3"
   gem "mysql2",                 "~> 0.3.0"
   gem "pg",                     "~> 0.9"
   gem "sqlite3-ruby",           "~> 1.3.1"


### PR DESCRIPTION
see https://github.com/igrigorik/...em-synchrony/issues/189

This pins the Gemfile to 1.0.3 which seems to work.

This gets the CI tests running again.