### PR TITLE
Improve support of STI models import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -349,6 +349,7 @@ class ActiveRecord::Base
         scope_columns.zip(scope_values).each do |name, value|
           name = name.to_sym
           next if column_names.include?(name)
+          next if name.to_s == inheritance_column.to_s && value.is_a?(Array) # hello from STI
           column_names << name
           array_of_attributes.each { |attrs| attrs << value }
         end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -347,7 +347,8 @@ class ActiveRecord::Base
 
       unless scope_columns.blank?
         scope_columns.zip(scope_values).each do |name, value|
-          next if column_names.include?(name.to_sym)
+          name = name.to_sym
+          next if column_names.include?(name)
           column_names << name
           array_of_attributes.each { |attrs| attrs << value }
         end


### PR DESCRIPTION
Thanks for the gem.

1st commit:

AR.scoped_attributes has their name as string, so when appended to column_names must be symbolized (otherwise includes?() won't detect duplicates).


2nd commit:

AR adds to scoped attributes
{
type: 'STIModelClass'
"type" => ['STIModelClass','STIModelParentClass']
}

The :type is ok for us,
the second one is used for building STI search requests, but cannot be used for insert.
So I just ignore it.

