### PR TITLE
Fix global constant lookup

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -9,7 +9,7 @@ class ActiveRecord::Base
 end
 
 ActiveSupport.on_load(:active_record_connection_established) do |connection_pool|
-  if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
+  if !ActiveRecord.const_defined?(:Import, false) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
     require "activerecord-import/base"
   end
 


### PR DESCRIPTION
By default const_defined? looks for constant in all ancestors of the module including Object. 
In my case I included another gem in my project with global namespace "Import". After that activerecord-import stopped to require own code because ActiveRecord.const_defined?(:Import) returns true.
