### PR TITLE
Fix a typing issue to dedupe column_names on import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -377,7 +377,7 @@ class ActiveRecord::Base
       unless scope_columns.blank?
         scope_columns.zip(scope_values).each do |name, value|
           next if column_names.include?(name.to_sym)
-          column_names << name
+          column_names << name.to_sym
           array_of_attributes.each { |attrs| attrs << value }
         end
       end


### PR DESCRIPTION
I have a client that is using AR-import on an STI table and is upgrading to rails 4. This code breaks on upgrade because `scope_attributes` returns both `:type` and `"type"`. Since de-duping is happening via an `include?` check against a symbol, the inserted value should be cast to a symbol as well.