### PR TITLE
Fix Rails 4.2 Enum Support, fix for #139

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,3 @@
-mysql
-postgresql
-sqlite
+brew "mysql"
+brew "postgresql"
+brew "sqlite"

--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -9,7 +9,7 @@ class ActiveRecord::Base
 end
 
 ActiveSupport.on_load(:active_record_connection_established) do |connection_pool|
-  if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
+  if !ActiveRecord.const_defined?(:Import, false) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
     require "activerecord-import/base"
   end
 

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -270,7 +270,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              model.send( "#{name}_before_type_cast" )
+              model.read_attribute_before_type_cast(name.to_s)
             end
           # end
         end

--- a/lib/activerecord-import/version.rb
+++ b/lib/activerecord-import/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Import
-    VERSION = "0.8.0"
+    VERSION = "0.9.0"
   end
 end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -365,6 +365,34 @@ describe "#import" do
 
   end
 
+  context 'When importing models with Enum fields' do
+    it 'should be able to import enum fields' do
+      Book.delete_all if Book.count > 0
+      books = [
+        Book.new(:author_name => "Foo", :title => "Baz", status: 0),
+        Book.new(:author_name => "Foo2", :title => "Baz2", status: 1),
+      ]
+      Book.import books
+      assert_equal 2, Book.count
+      assert_equal 0, Book.first.read_attribute('status')
+      assert_equal 1, Book.last.read_attribute('status')
+    end
+
+    if ENV['AR_VERSION'].to_i > 4.1
+      it 'should be able to import enum fields by name' do
+        Book.delete_all if Book.count > 0
+        books = [
+          Book.new(:author_name => "Foo", :title => "Baz", status: :draft),
+          Book.new(:author_name => "Foo2", :title => "Baz2", status: :published),
+        ]
+        Book.import books
+        assert_equal 2, Book.count
+        assert_equal 0, Book.first.read_attribute('status')
+        assert_equal 1, Book.last.read_attribute('status')
+      end
+    end
+  end
+
   describe "importing when model has default_scope" do
     it "doesn't import the default scope values" do
       assert_difference "Widget.unscoped.count", +2 do

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -2,4 +2,7 @@ class Book < ActiveRecord::Base
   belongs_to :topic, :inverse_of=>:books
   has_many :chapters, :autosave => true, :inverse_of => :book
   has_many :end_notes, :autosave => true, :inverse_of => :book
+  if ENV['AR_VERSION'].to_i >= 4.1
+    enum status: [:draft, :published]
+  end
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define do
     t.column :publish_date, :date
     t.column :topic_id, :integer
     t.column :for_sale, :boolean, :default => true
+    t.column :status, :integer
   end
 
   create_table :chapters, :force => true do |t|

--- a/test/schema/mysql_schema.rb
+++ b/test/schema/mysql_schema.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define do
     t.column :publish_date, :date
     t.column :topic_id, :integer
     t.column :for_sale, :boolean, :default => true
+    t.column :status, :integer
   end
   execute "ALTER TABLE books ADD FULLTEXT( `title`, `publisher`, `author_name` )"
 


### PR DESCRIPTION
This is a fix for supporting ActiveRecord::Enum on Rails 4.2. I checked all tests to make sure they pass.