### PR TITLE
Set new_record to false after set model ids

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -419,6 +419,7 @@ class ActiveRecord::Base
         import_result.ids.each_with_index do |id, index|
           models[index].id = id.to_i
           models[index].instance_variable_get(:@changed_attributes).clear # mark the model as saved
+          models[index].instance_variable_set(:@new_record, false)
         end
       end
     end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -139,7 +139,11 @@ describe "#import" do
 
       it "doesn't reload any data (doesn't work)" do
         Topic.import new_topics, :synchronize => new_topics
-        assert new_topics.all?(&:new_record?), "No record should have been reloaded"
+        if Topic.support_setting_primary_key_of_imported_objects?
+          assert new_topics.all?(&:persisted?), "Records should have been reloaded"
+        else
+          assert new_topics.all?(&:new_record?), "No record should have been reloaded"
+        end
       end
     end
 


### PR DESCRIPTION
This is needed to avoid that rails try to save a new object of this
model if later you use one of the imported objects (with the id set) in
an association with other new model that is being saved in database.