### PR TITLE
Support MySQL strict mode, and use for tests

### DIFF
--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 def should_support_mysql_import_functionality
   # Forcefully disable strict mode for this session.
-  ActiveRecord::Base.connection.execute "set sql_mode=''"
+  ActiveRecord::Base.connection.execute "set sql_mode='STRICT_ALL_TABLES'"
 
   describe "#import with :on_duplicate_key_update option (mysql specific functionality)" do
     extend ActiveSupport::TestCase::MySQLAssertions
@@ -141,8 +141,8 @@ def should_support_mysql_import_functionality
 
   describe "#import with :synchronization option" do
     let(:topics){ Array.new }
-    let(:values){ [ [topics.first.id, "Jerry Carter"], [topics.last.id, "Chad Fowler"] ]}
-    let(:columns){ %W(id author_name) }
+    let(:values){ [ [topics.first.id, "Jerry Carter", "title1"], [topics.last.id, "Chad Fowler", "title2"] ]}
+    let(:columns){ %W(id author_name title) }
 
     setup do
       topics << Topic.create!(:title=>"LDAP", :author_name=>"Big Bird")


### PR DESCRIPTION
Currently the MySQL test suite explicitly disables MySQL strict mode. The test suite passes in strict mode with changes to only one test though, and strict mode is now the default [as of Rails 4](http://guides.rubyonrails.org/4_0_release_notes.html), so it seems preferable to test in strict mode.