### PR TITLE
postgresql adapter clears cache on insert_many

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -13,6 +13,8 @@ module ActiveRecord::Import::PostgreSQLAdapter
     sql2insert = base_sql + values.join( ',' ) + post_sql
     ids = select_values( sql2insert, *args )
 
+    ActiveRecord::Base.connection.query_cache.clear
+
     [number_of_inserts,ids]
   end
 

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -101,5 +101,29 @@ def should_support_postgresql_import_functionality
         end
       end
     end
+
+    describe "with query cache enabled" do
+      setup do
+        unless ActiveRecord::Base.connection.query_cache_enabled
+          ActiveRecord::Base.connection.enable_query_cache!
+          @disable_cache_on_teardown = true
+        end
+      end
+
+      it "clears cache on insert" do
+        before_import = Topic.all.to_a
+
+        Topic.import(Build(2, :topics), validate: false)
+
+        after_import = Topic.all.to_a
+        assert_equal 2, after_import.size - before_import.size
+      end
+
+      teardown do
+        if @disable_cache_on_teardown
+          ActiveRecord::Base.connection.disable_query_cache!
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Commit ee7411acaf32db233edb611e3d0ed885a2b589f5 defined an `insert_many` method in `ActiveRecord::Import::PostgreSQLAdapter`. As this method uses `select_values`, the ActiveRecord query cache is not invalidated after the query is executed.

This pull request invalidates the cache by calling `ActiveRecord::Base.connection.query_cache.clear` immediately after `select_values` is called.