### PR TITLE
Add :on_duplicate_key_update support for Postgres

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -44,8 +44,13 @@ module ActiveRecord::Import::AbstractAdapter
     # Returns an array of post SQL statements given the passed in options.
     def post_sql_statements( table_name, options ) # :nodoc:
       post_sql_statements = []
-      if options[:on_duplicate_key_update]
-        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update] )
+
+      if supports_on_duplicate_key_update?
+        if options[:on_duplicate_key_ignore] && respond_to?(:sql_for_on_duplicate_key_ignore)
+          post_sql_statements << sql_for_on_duplicate_key_ignore( table_name, options[:on_duplicate_key_ignore] )
+        elsif options[:on_duplicate_key_update]
+          post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update] )
+        end
       end
 
       #custom user post_sql
@@ -61,6 +66,10 @@ module ActiveRecord::Import::AbstractAdapter
     # in a single packet
     def max_allowed_packet
       NO_MAX_PACKET
+    end
+
+    def supports_on_duplicate_key_update?
+      false
     end
   end
 end

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -60,6 +60,19 @@ module ActiveRecord::Import::MysqlAdapter
     end
   end
 
+  # Add a column to be updated on duplicate key update
+  def add_column_for_on_duplicate_key_update( column, options={} ) # :nodoc:
+    if options.include?(:on_duplicate_key_update)
+      columns = options[:on_duplicate_key_update]
+      case columns
+      when Array then columns << column.to_sym unless columns.include?(column.to_sym)
+      when Hash then columns[column.to_sym] = column.to_sym
+      end
+    else
+      options[:on_duplicate_key_update] = [ column.to_sym ]
+    end
+  end
+
   # Returns a generated ON DUPLICATE KEY UPDATE statement given the passed
   # in +args+.
   def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
@@ -86,7 +99,6 @@ module ActiveRecord::Import::MysqlAdapter
   end
 
   def sql_for_on_duplicate_key_update_as_hash( table_name, hsh ) # :nodoc:
-    sql = ' ON DUPLICATE KEY UPDATE '
     results = hsh.map do |column1, column2|
       qc1 = quote_column_name( column1 )
       qc2 = quote_column_name( column2 )
@@ -95,7 +107,7 @@ module ActiveRecord::Import::MysqlAdapter
     results.join( ',')
   end
 
-  #return true if the statement is a duplicate key record error
+  # Return true if the statement is a duplicate key record error
   def duplicate_key_update_error?(exception)# :nodoc:
     exception.is_a?(ActiveRecord::StatementInvalid) && exception.to_s.include?('Duplicate entry')
   end

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -1,5 +1,8 @@
 module ActiveRecord::Import::PostgreSQLAdapter
   include ActiveRecord::Import::ImportSupport
+  include ActiveRecord::Import::OnDuplicateKeyUpdateSupport
+
+  MIN_VERSION_FOR_UPSERT = 90500
 
   def insert_many( sql, values, *args ) # :nodoc:
     number_of_inserts = 1
@@ -24,10 +27,111 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
   def post_sql_statements( table_name, options ) # :nodoc:
     unless options[:primary_key].blank?
-      super(table_name, options) << (" RETURNING #{options[:primary_key]}")
+      super(table_name, options) << ("RETURNING #{options[:primary_key]}")
     else
       super(table_name, options)
     end
+  end
+
+  # Add a column to be updated on duplicate key update
+  def add_column_for_on_duplicate_key_update( column, options={} ) # :nodoc:
+    arg = options[:on_duplicate_key_update]
+    if arg.is_a?( Hash )
+      columns = arg.fetch( :columns ) { arg[:columns] = [] }
+      case columns
+      when Array then columns << column.to_sym unless columns.include?( column.to_sym )
+      when Hash then columns[column.to_sym] = column.to_sym
+      end
+    elsif arg.is_a?( Array )
+      arg << column.to_sym unless arg.include?( column.to_sym )
+    end
+  end
+
+  # Returns a generated ON CONFLICT DO NOTHING statement given the passed
+  # in +args+.
+  def sql_for_on_duplicate_key_ignore( table_name, *args ) # :nodoc:
+    arg = args.first
+    if arg.is_a?( Hash )
+      conflict_target = sql_for_conflict_target( arg )
+    end
+    " ON CONFLICT #{conflict_target}DO NOTHING"
+  end
+
+  # Returns a generated ON CONFLICT DO UPDATE statement given the passed
+  # in +args+.
+  def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
+    arg = args.first
+    if arg.is_a?( Array ) || arg.is_a?( String )
+      arg = { :columns => arg }
+    end
+    return unless arg.is_a?( Hash )
+
+    sql = " ON CONFLICT "
+    conflict_target = sql_for_conflict_target( arg )
+
+    columns = arg.fetch( :columns, [] )
+    if columns.respond_to?( :empty? ) && columns.empty?
+      return sql << "#{conflict_target}DO NOTHING"
+    end
+
+    conflict_target ||= sql_for_default_conflict_target( table_name )
+    unless conflict_target
+      raise ArgumentError, 'Expected :conflict_target or :constraint_name to be specified'
+    end
+
+    sql << "#{conflict_target}DO UPDATE SET "
+    if columns.is_a?( Array )
+      sql << sql_for_on_duplicate_key_update_as_array( table_name, columns )
+    elsif columns.is_a?( Hash )
+      sql << sql_for_on_duplicate_key_update_as_hash( table_name, columns )
+    elsif columns.is_a?( String )
+      sql << columns
+    else
+      raise ArgumentError, 'Expected :columns to be an Array or Hash'
+    end
+    sql
+  end
+
+  def sql_for_on_duplicate_key_update_as_array( table_name, arr )  # :nodoc:
+    results = arr.map do |column|
+      qc = quote_column_name( column )
+      "#{qc}=EXCLUDED.#{qc}"
+    end
+    results.join( ',' )
+  end
+
+  def sql_for_on_duplicate_key_update_as_hash( table_name, hsh ) # :nodoc:
+    results = hsh.map do |column1, column2|
+      qc1 = quote_column_name( column1 )
+      qc2 = quote_column_name( column2 )
+      "#{qc1}=EXCLUDED.#{qc2}"
+    end
+    results.join( ',' )
+  end
+
+  def sql_for_conflict_target( args={} )
+    if constraint_name = args[:constraint_name]
+      "ON CONSTRAINT #{constraint_name} "
+    elsif conflict_target = args[:conflict_target]
+      '(' << Array( conflict_target ).join( ', ' ) << ') '
+    end
+  end
+
+  def sql_for_default_conflict_target( table_name )
+    "(#{primary_key( table_name )}) "
+  end
+
+  # Return true if the statement is a duplicate key record error
+  def duplicate_key_update_error?(exception)# :nodoc:
+    exception.is_a?(ActiveRecord::StatementInvalid) && exception.to_s.include?('duplicate key')
+  end
+
+  def supports_on_duplicate_key_update?(current_version=self.postgresql_version)
+    current_version >= MIN_VERSION_FOR_UPSERT
+  end
+
+  def supports_on_duplicate_key_ignore?(current_version=self.postgresql_version)
+    supports_on_duplicate_key_update?(current_version)
   end
 
   def support_setting_primary_key_of_imported_objects?

--- a/test/em_mysql2/import_test.rb
+++ b/test/em_mysql2/import_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/jdbcmysql/import_test.rb
+++ b/test/jdbcmysql/import_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/jdbcpostgresql/import_test.rb
+++ b/test/jdbcpostgresql/import_test.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
-#require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
 
 should_support_postgresql_import_functionality

--- a/test/models/promotion.rb
+++ b/test/models/promotion.rb
@@ -1,0 +1,3 @@
+class Promotion < ActiveRecord::Base
+   self.primary_key = :promotion_id
+end

--- a/test/mysql/import_test.rb
+++ b/test/mysql/import_test.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
-
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/mysql2/import_test.rb
+++ b/test/mysql2/import_test.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
-
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/mysqlspatial/import_test.rb
+++ b/test/mysqlspatial/import_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/mysqlspatial2/import_test.rb
+++ b/test/mysqlspatial2/import_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
-require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/assertions')
+require File.expand_path(File.dirname(__FILE__) + '/../support/assertions')
 require File.expand_path(File.dirname(__FILE__) + '/../support/mysql/import_examples')
 
 should_support_mysql_import_functionality

--- a/test/postgresql/import_test.rb
+++ b/test/postgresql/import_test.rb
@@ -2,3 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
 
 should_support_postgresql_import_functionality
+
+if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+  should_support_postgresql_upsert_functionality
+end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -118,4 +118,12 @@ ActiveRecord::Schema.define do
     t.text    :data
     t.text    :json_data
   end
+
+  create_table "promotions", primary_key: "promotion_id", force: :cascade do |t|
+    t.string   :code
+    t.string   :description
+    t.decimal  :discount
+  end
+
+  add_index :promotions, [:code], :unique => true, :name => 'uk_code'
 end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -1,5 +1,5 @@
 class ActiveSupport::TestCase
-  module MySQLAssertions
+  module ImportAssertions
     def self.extended(klass)
       klass.instance_eval do
         assertion(:should_not_update_created_at_on_timestamp_columns) do
@@ -16,6 +16,15 @@ class ActiveSupport::TestCase
             perform_import
             assert_in_delta time.to_i, updated_topic.updated_at.to_i, 1
             assert_in_delta time.to_i, updated_topic.updated_on.to_i, 1
+          end
+        end
+
+        assertion(:should_not_update_updated_at_on_timestamp_columns) do
+          time = Chronic.parse("5 minutes from now")
+          Timecop.freeze time do
+            perform_import
+            assert_in_delta @topic.updated_at.to_i, updated_topic.updated_at.to_i, 1
+            assert_in_delta @topic.updated_on.to_i, updated_topic.updated_on.to_i, 1
           end
         end
 
@@ -40,10 +49,10 @@ class ActiveSupport::TestCase
         end
 
         assertion(:should_raise_update_fields_mentioned) do
-          assert_raise ActiveRecord::RecordNotUnique do 
+          assert_raise ActiveRecord::RecordNotUnique do
             perform_import
           end
-          
+
           assert_equal "Book", updated_topic.title
           assert_equal "john@doe.com", updated_topic.author_email_address
         end

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -3,29 +3,22 @@ def should_support_mysql_import_functionality
   # Forcefully disable strict mode for this session.
   ActiveRecord::Base.connection.execute "set sql_mode='STRICT_ALL_TABLES'"
 
-  describe "#import with :on_duplicate_key_update option (mysql specific functionality)" do
-    extend ActiveSupport::TestCase::MySQLAssertions
+  should_support_basic_on_duplicate_key_update
 
-    asssertion_group(:should_support_on_duplicate_key_update) do
-      should_not_update_fields_not_mentioned
-      should_update_foreign_keys
-      should_not_update_created_at_on_timestamp_columns
-      should_update_updated_at_on_timestamp_columns
-    end
+  describe "#import" do
+    context "with :on_duplicate_key_update and validation checks turned off" do
+      extend ActiveSupport::TestCase::ImportAssertions
 
-    macro(:perform_import){ raise "supply your own #perform_import in a context below" }
-    macro(:updated_topic){ Topic.find(@topic.id) }
-
-    describe "argument safety" do
-      it "should not modify the passed in :on_duplicate_key_update columns array" do
-        assert_nothing_raised do
-          columns = %w(title author_name).freeze
-          Topic.import columns, [["foo", "bar"]], :on_duplicate_key_update => columns
-        end
+      asssertion_group(:should_support_on_duplicate_key_update) do
+        should_not_update_fields_not_mentioned
+        should_update_foreign_keys
+        should_not_update_created_at_on_timestamp_columns
+        should_update_updated_at_on_timestamp_columns
       end
-    end
 
-    context "given columns and values with :validation checks turned off" do
+      macro(:perform_import){ raise "supply your own #perform_import in a context below" }
+      macro(:updated_topic){ Topic.find(@topic.id) }
+
       let(:columns){  %w( id title author_name author_email_address parent_id ) }
       let(:values){ [ [ 99, "Book", "John Doe", "john@doe.com", 17 ] ] }
       let(:updated_values){ [ [ 99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
@@ -39,18 +32,6 @@ def should_support_mysql_import_functionality
         @topic = Topic.find 99
       end
 
-      context "using string column names" do
-        let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
-
-      context "using symbol column names" do
-        let(:update_columns){ [ :title, :author_email_address, :parent_id ] }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
-
       context "using string hash map" do
         let(:update_columns){ { "title" => "title", "author_email_address" => "author_email_address", "parent_id" => "parent_id" } }
         should_support_on_duplicate_key_update
@@ -76,101 +57,29 @@ def should_support_mysql_import_functionality
       end
     end
 
-    context "given array of model instances with :validation checks turned off" do
-      macro(:perform_import) do |*opts|
-        @topic.title = "Book - 2nd Edition"
-        @topic.author_name = "Author Should Not Change"
-        @topic.author_email_address = "johndoe@example.com"
-        @topic.parent_id = 57
-        Topic.import [@topic], opts.extract_options!.merge(:on_duplicate_key_update => update_columns, :validate => false)
-      end
+    context "with :synchronization option" do
+      let(:topics){ Array.new }
+      let(:values){ [ [topics.first.id, "Jerry Carter", "title1"], [topics.last.id, "Chad Fowler", "title2"] ]}
+      let(:columns){ %W(id author_name title) }
 
       setup do
-        @topic = Generate(:topic, :id => 99, :author_name => "John Doe", :parent_id => 17)
+        topics << Topic.create!(:title=>"LDAP", :author_name=>"Big Bird")
+        topics << Topic.create!(:title=>"Rails Recipes", :author_name=>"Elmo")
       end
 
-      context "using string column names" do
-        let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
+      it "synchronizes passed in ActiveRecord model instances with the data just imported" do
+        columns2update = [ 'author_name' ]
 
-      context "using symbol column names" do
-        let(:update_columns){ [ :title, :author_email_address, :parent_id ] }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
+        expected_count = Topic.count
+        Topic.import( columns, values,
+          :validate=>false,
+          :on_duplicate_key_update=>columns2update,
+          :synchronize=>topics )
 
-      context "using string hash map" do
-        let(:update_columns){ { "title" => "title", "author_email_address" => "author_email_address", "parent_id" => "parent_id" } }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
-
-      context "using string hash map, but specifying column mismatches" do
-        let(:update_columns){ { "title" => "author_email_address", "author_email_address" => "title", "parent_id" => "parent_id" } }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned_with_hash_mappings
-      end
-
-      context "using symbol hash map" do
-        let(:update_columns){ { :title => :title, :author_email_address => :author_email_address, :parent_id => :parent_id } }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
-
-      context "using symbol hash map, but specifying column mismatches" do
-        let(:update_columns){ { :title => :author_email_address, :author_email_address => :title, :parent_id => :parent_id } }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned_with_hash_mappings
-      end
-    end
-  
-    context "given array of model instances with :on_duplicate_key_update turned off" do
-      let(:columns){  %w( id title author_name author_email_address parent_id ) }
-      let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com", 17 ] ] }
-      let(:updated_values){ [ [ 100, "Book - 2nd Edition", "This should raise an exception", "john@nogo.com", 57 ] ] }
-
-      macro(:perform_import) do |*opts|
-        # `:on_duplicate_key_update => false` is the tested feature
-        Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => false, :validate => false)
-      end
-
-      setup do
-        Topic.import columns, values, :validate => false
-        @topic = Topic.find 100
-      end
-    
-      context "using string column names" do
-        let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
-        should_raise_update_fields_mentioned
+        assert_equal expected_count, Topic.count, "no new records should have been created!"
+        assert_equal "Jerry Carter",  topics.first.author_name, "wrong author!"
+        assert_equal "Chad Fowler", topics.last.author_name, "wrong author!"
       end
     end
   end
-
-  describe "#import with :synchronization option" do
-    let(:topics){ Array.new }
-    let(:values){ [ [topics.first.id, "Jerry Carter", "title1"], [topics.last.id, "Chad Fowler", "title2"] ]}
-    let(:columns){ %W(id author_name title) }
-
-    setup do
-      topics << Topic.create!(:title=>"LDAP", :author_name=>"Big Bird")
-      topics << Topic.create!(:title=>"Rails Recipes", :author_name=>"Elmo")
-    end
-
-    it "synchronizes passed in ActiveRecord model instances with the data just imported" do
-      columns2update = [ 'author_name' ]
-
-      expected_count = Topic.count
-      Topic.import( columns, values,
-        :validate=>false,
-        :on_duplicate_key_update=>columns2update,
-        :synchronize=>topics )
-
-      assert_equal expected_count, Topic.count, "no new records should have been created!"
-      assert_equal "Jerry Carter",  topics.first.author_name, "wrong author!"
-      assert_equal "Chad Fowler", topics.last.author_name, "wrong author!"
-    end
-  end
-
 end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -19,7 +19,6 @@ def should_support_postgresql_import_functionality
     end
 
     describe "importing objects with associations" do
-
       let(:new_topics) { Build(num_topics, :topic_with_book) }
       let(:new_topics_with_invalid_chapter) {
          chapter = new_topics.first.books.first.chapters.first
@@ -122,6 +121,154 @@ def should_support_postgresql_import_functionality
       teardown do
         if @disable_cache_on_teardown
           ActiveRecord::Base.connection.disable_query_cache!
+        end
+      end
+    end
+  end
+end
+
+def should_support_postgresql_upsert_functionality
+  should_support_basic_on_duplicate_key_update
+
+  describe "#import" do
+    extend ActiveSupport::TestCase::ImportAssertions
+
+    macro(:perform_import){ raise "supply your own #perform_import in a context below" }
+    macro(:updated_topic){ Topic.find(@topic.id) }
+
+    context "with :on_duplicate_key_ignore and validation checks turned off" do
+      let(:columns){  %w( id title author_name author_email_address parent_id ) }
+      let(:values){ [ [ 99, "Book", "John Doe", "john@doe.com", 17 ] ] }
+      let(:updated_values){ [ [ 99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
+
+      macro(:perform_import) do |*opts|
+        Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_ignore => value, :validate => false)
+      end
+
+      setup do
+        Topic.import columns, values, :validate => false
+        @topic = Topic.find 99
+      end
+
+      context "using true" do
+        let(:value){ true }
+        should_not_update_updated_at_on_timestamp_columns
+      end
+
+      context "using hash with :conflict_target" do
+        let(:value){ { conflict_target: :id } }
+        should_not_update_updated_at_on_timestamp_columns
+      end
+
+      context "using hash with :constraint_target" do
+        let(:value){ { constraint_name: :topics_pkey } }
+        should_not_update_updated_at_on_timestamp_columns
+      end
+    end
+
+    context "with :on_duplicate_key_update and validation checks turned off" do
+      asssertion_group(:should_support_on_duplicate_key_update) do
+        should_not_update_fields_not_mentioned
+        should_update_foreign_keys
+        should_not_update_created_at_on_timestamp_columns
+        should_update_updated_at_on_timestamp_columns
+      end
+
+      context "using a hash" do
+        context "with :columns a hash" do
+          let(:columns){  %w( id title author_name author_email_address parent_id ) }
+          let(:values){ [ [ 99, "Book", "John Doe", "john@doe.com", 17 ] ] }
+          let(:updated_values){ [ [ 99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
+
+          macro(:perform_import) do |*opts|
+            Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => { :conflict_target => :id, :columns => update_columns }, :validate => false)
+          end
+
+          setup do
+            Topic.import columns, values, :validate => false
+            @topic = Topic.find 99
+          end
+
+          context "using string hash map" do
+            let(:update_columns){ { "title" => "title", "author_email_address" => "author_email_address", "parent_id" => "parent_id" } }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
+
+          context "using string hash map, but specifying column mismatches" do
+            let(:update_columns){ { "title" => "author_email_address", "author_email_address" => "title", "parent_id" => "parent_id" } }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned_with_hash_mappings
+          end
+
+          context "using symbol hash map" do
+            let(:update_columns){ { :title => :title, :author_email_address => :author_email_address, :parent_id => :parent_id } }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
+
+          context "using symbol hash map, but specifying column mismatches" do
+            let(:update_columns){ { :title => :author_email_address, :author_email_address => :title, :parent_id => :parent_id } }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned_with_hash_mappings
+          end
+        end
+
+        context "with :constraint_name" do
+          let(:columns){  %w( id title author_name author_email_address parent_id ) }
+          let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com", 17 ] ] }
+          let(:updated_values){ [ [ 100, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
+
+          macro(:perform_import) do |*opts|
+            Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => { :constraint_name => :topics_pkey, :columns => update_columns }, :validate => false)
+          end
+
+          setup do
+            Topic.import columns, values, :validate => false
+            @topic = Topic.find 100
+          end
+
+          let(:update_columns){ [ :title, :author_email_address, :parent_id ] }
+          should_support_on_duplicate_key_update
+          should_update_fields_mentioned
+        end
+
+        context "with no :conflict_target or :constraint_name" do
+          let(:columns){  %w( id title author_name author_email_address parent_id ) }
+          let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com", 17 ] ] }
+          let(:updated_values){ [ [ 100, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
+
+          macro(:perform_import) do |*opts|
+            Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => { :columns => update_columns }, :validate => false)
+          end
+
+          setup do
+            Topic.import columns, values, :validate => false
+            @topic = Topic.find 100
+          end
+
+          context "default to the primary key" do
+            let(:update_columns){ [ :title, :author_email_address, :parent_id ] }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
+        end
+
+        context "with no :columns" do
+          let(:columns){  %w( id title author_name author_email_address ) }
+          let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com" ] ] }
+          let(:updated_values){ [ [ 100, "Title Should Not Change", "Author Should Not Change", "john@nogo.com" ] ] }
+
+          macro(:perform_import) do |*opts|
+            Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => { :conflict_target => :id }, :validate => false)
+          end
+
+          setup do
+            Topic.import columns, values, :validate => false
+            @topic = Topic.find 100
+          end
+
+          should_update_updated_at_on_timestamp_columns
         end
       end
     end

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -1,0 +1,92 @@
+def should_support_basic_on_duplicate_key_update
+  describe "#import" do
+    extend ActiveSupport::TestCase::ImportAssertions
+
+    macro(:perform_import){ raise "supply your own #perform_import in a context below" }
+    macro(:updated_topic){ Topic.find(@topic.id) }
+
+    context "with :on_duplicate_key_update and validation checks turned off" do
+      asssertion_group(:should_support_on_duplicate_key_update) do
+        should_not_update_fields_not_mentioned
+        should_update_foreign_keys
+        should_not_update_created_at_on_timestamp_columns
+        should_update_updated_at_on_timestamp_columns
+      end
+
+      let(:columns){  %w( id title author_name author_email_address parent_id ) }
+      let(:values){ [ [ 99, "Book", "John Doe", "john@doe.com", 17 ] ] }
+      let(:updated_values){ [ [ 99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57 ] ] }
+
+      macro(:perform_import) do |*opts|
+        Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => update_columns , :validate => false)
+      end
+
+      setup do
+        Topic.import columns, values, :validate => false
+        @topic = Topic.find 99
+      end
+
+      context "using an empty array" do
+        let(:update_columns){ [] }
+        should_not_update_fields_not_mentioned
+        should_update_updated_at_on_timestamp_columns
+      end
+
+      context "using string column names" do
+        let(:update_columns){ [ "title", "author_email_address", "parent_id" ] }
+        should_support_on_duplicate_key_update
+        should_update_fields_mentioned
+      end
+
+      context "using symbol column names" do
+        let(:update_columns){ [ :title, :author_email_address, :parent_id ] }
+        should_support_on_duplicate_key_update
+        should_update_fields_mentioned
+      end
+    end
+
+    context "with a table that has a non-standard primary key" do
+      let(:columns){ [ :promotion_id, :code ] }
+      let(:values){ [ [ 1, 'DISCOUNT1' ] ] }
+      let(:updated_values){ [ [ 1, 'DISCOUNT2'] ] }
+      let(:update_columns){ [ :code ] }
+
+      macro(:perform_import) do |*opts|
+        Promotion.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => update_columns, :validate => false)
+      end
+      macro(:updated_promotion){ Promotion.find(@promotion.promotion_id) }
+
+      setup do
+        Promotion.import columns, values, :validate => false
+        @promotion = Promotion.find 1
+      end
+
+      it "should update specified columns" do
+        perform_import
+        assert_equal 'DISCOUNT2', updated_promotion.code
+      end
+    end
+
+    context "with :on_duplicate_key_update turned off" do
+      let(:columns){  %w( id title author_name author_email_address parent_id ) }
+      let(:values){ [ [ 100, "Book", "John Doe", "john@doe.com", 17 ] ] }
+      let(:updated_values){ [ [ 100, "Book - 2nd Edition", "This should raise an exception", "john@nogo.com", 57 ] ] }
+
+      macro(:perform_import) do |*opts|
+        # `:on_duplicate_key_update => false` is the tested feature
+        Topic.import columns, updated_values, opts.extract_options!.merge(:on_duplicate_key_update => false, :validate => false)
+      end
+
+      setup do
+        Topic.import columns, values, :validate => false
+        @topic = Topic.find 100
+      end
+
+      it "should raise ActiveRecord::RecordNotUnique" do
+        assert_raise ActiveRecord::RecordNotUnique do
+          perform_import
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Postgres 9.5 added UPSERT support. Resolves #187.

Provides the following syntax:

```
Country.import [country], validate: false, on_duplicate_key_update: { conflict_target: :country, columns: [:updated_at] }
```

`:conflict_target` takes either a single value or an array of column names that make up the unique constraint and `:columns` could be either an array or hash similar to the existing MySQL functionality.