### PR TITLE
Don't use AS.on_load for something else than on_load hook

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -2,18 +2,15 @@ ActiveSupport.on_load(:active_record) do
   class ActiveRecord::Base
     class << self
       def establish_connection_with_activerecord_import(*args)
-        establish_connection_without_activerecord_import(*args)
-        ActiveSupport.run_load_hooks(:active_record_connection_established, connection_pool)
+        conn = establish_connection_without_activerecord_import(*args)
+        if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
+          require "activerecord-import/base"
+        end
+
+        ActiveRecord::Import.load_from_connection_pool connection_pool
+        conn
       end
       alias_method_chain :establish_connection, :activerecord_import
     end
   end
-end
-
-ActiveSupport.on_load(:active_record_connection_established) do |connection_pool|
-  if !ActiveRecord.const_defined?(:Import, false) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
-    require "activerecord-import/base"
-  end
-
-  ActiveRecord::Import.load_from_connection_pool connection_pool
 end


### PR DESCRIPTION
ActiveSupport.on_load is not just a way to add an additional block of code into a Ruby method.
It's a mechanism for adding load hooks which is needed to implement lazy loading in ActiveSupport.

And, in this particular after_established case, we don't actually need any special mechanism. Let's just simply call the logic inside the AMC.

This is to get changes in #177 implemented by @amatsuda  in.