### PR TITLE
Fix rails (> 4.1) enum column with a default integer value

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -275,7 +275,8 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              if ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+              env =  ENV['RAILS_ENV'] || Rails.env
+              if ActiveRecord::Base.configurations[env]["adapter"] == 'postgresql'
                 model.read_attribute(name.to_s)
               else
                 model.read_attribute_before_type_cast(name.to_s)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -276,7 +276,7 @@ class ActiveRecord::Base
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
               env =  ENV['RAILS_ENV'] || Rails.env
-              if ActiveRecord::Base.configurations[env]["adapter"] == 'postgresql'
+              if %w{postgresq em_mysql2}.include? ActiveRecord::Base.configurations[env]["adapter"]
                 model.read_attribute(name.to_s)
               else
                 model.read_attribute_before_type_cast(name.to_s)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -275,8 +275,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              env =  ENV['RAILS_ENV'] || Rails.env
-              if %w{postgresq em_mysql2}.include? ActiveRecord::Base.configurations[env]["adapter"]
+              if model.class.column_defaults[name.to_s].is_a? Integer
                 model.read_attribute(name.to_s)
               else
                 model.read_attribute_before_type_cast(name.to_s)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -275,7 +275,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              if ENV["ARE_DB"] == "postgresql"
+              if ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
                 model.read_attribute(name.to_s)
               else
                 model.read_attribute_before_type_cast(name.to_s)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -275,7 +275,11 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
             column_names.map do |name|
-              model.read_attribute_before_type_cast(name.to_s)
+              if ENV["ARE_DB"] == "postgresql"
+                model.read_attribute(name.to_s)
+              else
+                model.read_attribute_before_type_cast(name.to_s)
+              end
             end
           # end
         end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -404,7 +404,7 @@ describe "#import" do
       end
     end
 
-    if ENV['AR_VERSION'].to_i > 4.1
+    if ENV['AR_VERSION'].to_f > 4.1
       it 'should be able to import enum fields by name' do
         Book.delete_all if Book.count > 0
         books = [

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -2,7 +2,7 @@ class Book < ActiveRecord::Base
   belongs_to :topic, :inverse_of=>:books
   has_many :chapters, :autosave => true, :inverse_of => :book
   has_many :end_notes, :autosave => true, :inverse_of => :book
-  if ENV['AR_VERSION'].to_i >= 4.1
+  if ENV['AR_VERSION'].to_f >= 4.1
     enum status: [:draft, :published]
   end
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define do
     t.column :publish_date, :date
     t.column :topic_id, :integer
     t.column :for_sale, :boolean, :default => true
-    t.column :status, :integer
+    t.column :status, :integer, :default => 0
   end
 
   create_table :chapters, :force => true do |t|


### PR DESCRIPTION
First, _ENV['AR_VERSION'].to_i > 4.1_ is only true when _AR_VERSION >= 5_ because _to_i_ rounds down strings, e.g. _"4.2".to_i => 4_. Therefore, in 4.2 the enum in book.rb is not currently defined.

And the main stuff is, for many adapters the default value of an integer column is still in string format (like in postgresql by using pg_get_expr, check at: http://www.postgresql.org/docs/8.0/static/functions-info.html#AEN13319) before type casting. So during the importing, an argument error happens like _ArgumentError: '0' is not a valid status_, given 0 is the default value for status column. This issue seems not only to happen in postgresql.

There's no new test cases for this PR, because some existing tests get failed when default value is added and enum is enabled in book.rb. Certainly, the implement fixes all of them.




