### PR TITLE
Cleanup Rails 5 deprecation warnings in tests

### DIFF
--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -7,7 +7,7 @@ ActiveRecord::Schema.define do
 
   create_table :group, :force => true do |t|
     t.column :order, :string
-    t.timestamps
+    t.timestamps null: true
   end
 
   create_table :topics, :force=>true do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,3 +55,7 @@ Dir[File.dirname(__FILE__) + "/models/*.rb"].each{ |file| require file }
 
 # Prevent this deprecation warning from breaking the tests.
 Rake::FileList.send(:remove_method, :import)
+
+if ENV['AR_VERSION'].to_f >= 4.2
+  ActiveSupport::TestCase.test_order = :sorted
+end


### PR DESCRIPTION
When running the tests for AR 4.2 the following deprecation warnings are displayed:

```
DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`.
In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true`
to prevent the behavior of your existing migrations from changing. (called from block (2 levels)
in <top (required)> at /Users/jordan/projects/activerecord-import/test/schema/generic_schema.rb:10)
```

```
DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`.
In Rails 5, the default value of this option will change from `:sorted` to `:random`.
To disable this warning and keep the current behavior, you can add the following
line to your `config/environments/test.rb`:

  Rails.application.configure do
    config.active_support.test_order = :sorted
  end

Alternatively, you can opt into the future behavior by setting this option to `:random`. 
(called from test_order at 
/Users/jordan/.rvm/gems/ruby-2.2.4/gems/activesupport-4.2.5.1/lib/active_support/test_case.rb:42)
```

In this pull request I stuck with existing behavior for both.
