### PR TITLE
Assign attributes directly during import validation

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -252,7 +252,7 @@ class ActiveRecord::Base
       # validation we'll use the index to remove it from the array_of_attributes
       arr.each_with_index do |hsh,i|
         instance = new do |model|
-          hsh.each_pair{ |k,v| model.send("#{k}=", v) }
+          hsh.each_pair{ |k,v| model[k] = v }
         end
         if not instance.valid?
           array_of_attributes[ i ] = nil


### PR DESCRIPTION
To prevent parsing UTC time into local datetime.