### PR TITLE
Remove tests for em_mysql2 adapter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :display do
 end
 task :default => ["display:notice"]
 
-ADAPTERS = %w(mysql mysql2 em_mysql2 jdbcmysql jdbcpostgresql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
+ADAPTERS = %w(mysql mysql2 jdbcmysql jdbcpostgresql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
 ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :display do
 end
 task :default => ["display:notice"]
 
-ADAPTERS = %w(mysql mysql2 jdbcmysql jdbcpostgresql postgresql sqlite3 seamless_database_pool mysqlspatial mysql2spatial spatialite postgis)
+ADAPTERS = %w(mysql2 jdbcmysql jdbcpostgresql postgresql sqlite3 seamless_database_pool mysql2spatial spatialite postgis)
 ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.1.0'
 end

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.1.0'
-  gem 'em-synchrony', '1.0.3'
 end

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.2.0'
 end

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '>= 2.8.1'
   gem 'activerecord', '~> 3.2.0'
-  gem 'em-synchrony', '1.0.3'
 end

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.0'
 end

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.0'
-  gem 'em-synchrony', '1.0.3'
 end

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.1'
-  gem 'em-synchrony', '1.0.4'
 end

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.1'
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.2'
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 4.2'
-  gem 'em-synchrony', '1.0.4'
 end

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,5 +1,4 @@
 platforms :ruby do
   gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 5.0.0.beta1'
-  gem 'em-synchrony', '1.0.4'
 end

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,4 +1,3 @@
 platforms :ruby do
-  gem 'mysql',        '~> 2.9'
   gem 'activerecord', '~> 5.0.0.beta1'
 end

--- a/test/adapters/em_mysql2.rb
+++ b/test/adapters/em_mysql2.rb
@@ -1,1 +1,0 @@
-ENV["ARE_DB"] = "em_mysql2"

--- a/test/adapters/mysql.rb
+++ b/test/adapters/mysql.rb
@@ -1,1 +1,0 @@
-ENV["ARE_DB"] = "mysql"

--- a/test/adapters/mysqlspatial.rb
+++ b/test/adapters/mysqlspatial.rb
@@ -1,1 +1,0 @@
-ENV["ARE_DB"] = "mysqlspatial"

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -19,11 +19,6 @@ mysqlspatial:
 mysql2spatial:
   <<: *mysql2
 
-em_mysql2:
-  <<: *common
-  adapter: em_mysql2
-  pool: 5
-
 seamless_database_pool:
   <<: *common
   adapter: seamless_database_pool

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -5,16 +5,9 @@ common: &common
   host:     localhost
   database: activerecord_import_test
 
-mysql: &mysql
-  <<: *common
-  adapter: mysql
-
 mysql2: &mysql2
   <<: *common
   adapter: mysql2
-
-mysqlspatial:
-  <<: *mysql
 
 mysql2spatial:
   <<: *mysql2

--- a/test/travis/build.sh
+++ b/test/travis/build.sh
@@ -12,10 +12,8 @@ for activerecord_version in "3.1" "3.2" "4.0" "4.1" "4.2" "5.0" ; do
 
   bundle update activerecord
 
-  run bundle exec rake test:mysql                   # Run tests for mysql
   run bundle exec rake test:mysql2                  # Run tests for mysql2
   run bundle exec rake test:mysql2spatial           # Run tests for mysql2spatial
-  run bundle exec rake test:mysqlspatial            # Run tests for mysqlspatial
   run bundle exec rake test:postgis                 # Run tests for postgis
   run bundle exec rake test:postgresql              # Run tests for postgresql
   run bundle exec rake test:seamless_database_pool  # Run tests for seamless_database_pool

--- a/test/travis/build.sh
+++ b/test/travis/build.sh
@@ -12,7 +12,6 @@ for activerecord_version in "3.1" "3.2" "4.0" "4.1" "4.2" "5.0" ; do
 
   bundle update activerecord
 
-  run bundle exec rake test:em_mysql2               # Run tests for em_mysql2
   run bundle exec rake test:mysql                   # Run tests for mysql
   run bundle exec rake test:mysql2                  # Run tests for mysql2
   run bundle exec rake test:mysql2spatial           # Run tests for mysql2spatial

--- a/test/travis/database.yml
+++ b/test/travis/database.yml
@@ -19,11 +19,6 @@ mysqlspatial:
 mysql2spatial:
   <<: *mysql2
 
-em_mysql2:
-  <<: *common
-  adapter: em_mysql2
-  pool: 5
-
 seamless_database_pool:
   <<: *common
   adapter: seamless_database_pool

--- a/test/travis/database.yml
+++ b/test/travis/database.yml
@@ -5,16 +5,9 @@ common: &common
   host:     localhost
   database: activerecord_import_test
 
-mysql: &mysql
-  <<: *common
-  adapter: mysql
-
 mysql2: &mysql2
   <<: *common
   adapter: mysql2
-
-mysqlspatial:
-  <<: *mysql
 
 mysql2spatial:
   <<: *mysql2


### PR DESCRIPTION
It appears that `em-synchrony` is no longer being updated and no longer works with recent versions of Active Record, causing the build to fail. This commit can be reverted when these `em-synchrony` issues are resolved.

Please see [this comment](https://github.com/zdennis/activerecord-import/pull/230#issuecomment-187023507) for additional rationale.