### PR TITLE
Updating travisci build to be less verbose on successful runs.

### DIFF
--- a/test/travis/build.sh
+++ b/test/travis/build.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
-set -e
-set +x
+# set -e
+# set +x
 
 function run {
-  echo "Running: AR_VERSION=$AR_VERSION $@"
-  $@
+  statement=$@
+  logfile=$4.log
+  $statement &> $logfile
+  if [ $? != 0 ] ; then
+    printf "AR_VERSION=$AR_VERSION $statement \e[31mFAILED\e[0m\n"
+    cat $logfile
+  else
+    printf "AR_VERSION=$AR_VERSION $statement \e[32mPASSED\e[0m\n"
+  fi
 }
 
 for activerecord_version in "3.1" "3.2" "4.0" "4.1" "4.2" "5.0" ; do
   export AR_VERSION=$activerecord_version
 
-  bundle update activerecord
+  bundle update activerecord > /dev/null
 
   run bundle exec rake test:mysql2                  # Run tests for mysql2
   run bundle exec rake test:mysql2spatial           # Run tests for mysql2spatial


### PR DESCRIPTION
This makes the output on TravisCI look like this in the success case:

![screenshot 2016-02-26 13 27 41](https://cloud.githubusercontent.com/assets/967/13361481/ee9bfeee-dc8c-11e5-95f8-8341178b8a2b.png)

In the failure case it will show the full output for which run failed.