### PR TITLE
Add :batch_size option to import

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -149,6 +149,26 @@ describe "#import" do
     end
   end
 
+  context "with :batch_size option" do
+    it "should import with a single insert" do
+      assert_difference "Topic.count", +10 do
+        result = Topic.import Build(10, :topics), batch_size: 10
+        if Topic.supports_import?
+          assert_equal 1, result.num_inserts
+        end
+      end
+    end
+
+    it "should import with multiple inserts" do
+      assert_difference "Topic.count", +10 do
+        result = Topic.import Build(10, :topics), batch_size: 4
+        if Topic.supports_import?
+          assert_equal 3, result.num_inserts
+        end
+      end
+    end
+  end
+
   context "with :synchronize option" do
     context "synchronizing on new records" do
       let(:new_topics) { Build(3, :topics) }


### PR DESCRIPTION
This resolves #207. Batch size defaults to the total number of records to import. I considered using 1000 records per insert as a default as that seems to be fairly standard, but I decided it might be better to have it as an explicit option for now. I'm open to other suggestions :smile: 

See [ActiveRecord::Batches](http://api.rubyonrails.org/classes/ActiveRecord/Batches.html).