### PR TITLE
Add import! method

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -312,6 +312,16 @@ class ActiveRecord::Base
       end
     end
 
+    # Imports a collection of values if all values are valid. Import fails at the
+    # first encountered validation error and raises ActiveRecord::RecordInvalid
+    # with the failed instance.
+    def import!(*args)
+      options = args.last.is_a?( Hash ) ? args.pop : {}
+      options.merge!( { validate: true, raise_error: true } )
+
+      import(*args, options)
+    end
+
     def import_helper( *args )
       options = { validate: true, timestamps: true, primary_key: primary_key }
       options.merge!( args.pop ) if args.last.is_a? Hash
@@ -425,6 +435,7 @@ class ActiveRecord::Base
         end
 
         unless instance.valid?(options[:validate_with_context])
+          raise ActiveRecord::RecordInvalid.new(instance) if options[:raise_error]
           array_of_attributes[i] = nil
           failed_instances << instance
         end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -456,4 +456,28 @@ describe "#import" do
       end
     end
   end
+
+  describe "#import!" do
+    let(:columns) { %w(title author_name) }
+    let(:valid_values) { [[ "LDAP", "Jerry Carter"], ["Rails Recipes", "Chad Fowler"]] }
+    let(:invalid_values) { [["Rails Recipes", "Chad Fowler"], [ "The RSpec Book", ""], ["Agile+UX", ""]] }
+
+    context "with invalid data" do
+      it "should raise ActiveRecord::RecordInvalid" do
+        assert_no_difference "Topic.count" do
+          assert_raise ActiveRecord::RecordInvalid do
+            Topic.import! columns, invalid_values
+          end
+        end
+      end
+    end
+
+    context "with valid data" do
+      it "should import data" do
+        assert_difference "Topic.count", +2 do
+          Topic.import! columns, valid_values
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using `import!` an ActiveRecord::RecordInvalid error is raised if any of the validations fail. Resolves #162.