### PR TITLE
Drop support for Rails 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     # https://github.com/discourse/discourse/blob/master/.travis.yml
     - RUBY_GC_MALLOC_LIMIT=50000000
   matrix:
-    - AR_VERSION=3.1
     - AR_VERSION=3.2
     - AR_VERSION=4.0
     - AR_VERSION=4.1

--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.2"
 
-  gem.add_runtime_dependency "activerecord", ">= 3.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.2"
   gem.add_development_dependency "rake"
 end

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,3 +1,0 @@
-platforms :ruby do
-  gem 'activerecord', '~> 3.1.0'
-end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -517,7 +517,7 @@ class ActiveRecord::Base
         model.id = id.to_i
         if model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
           model.clear_changes_information
-        else # Rails 3.1
+        else # Rails 3.2
           model.instance_variable_get(:@changed_attributes).clear
         end
         model.instance_variable_set(:@new_record, false)
@@ -590,7 +590,7 @@ class ActiveRecord::Base
               connection_memo.quote(type_caster.type_cast_for_database(column.name, val))
             elsif column.respond_to?(:type_cast_from_user)                                   # Rails 4.2 and higher
               connection_memo.quote(column.type_cast_from_user(val), column)
-            else                                                                             # Rails 3.1, 3.2, 4.0 and 4.1
+            else                                                                             # Rails 3.2, 4.0 and 4.1
               if serialized_attributes.include?(column.name)
                 val = serialized_attributes[column.name].dump(val)
               end

--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -47,7 +47,7 @@ module ActiveRecord # :nodoc:
           instance.clear_changes_information                      # Rails 4.2 and higher
         else
           instance.instance_variable_set :@attributes_cache, {}   # Rails 4.0, 4.1
-          instance.changed_attributes.clear                       # Rails 3.1, 3.2
+          instance.changed_attributes.clear                       # Rails 3.2
           instance.previous_changes.clear
         end
 


### PR DESCRIPTION
Rails 3.1 is no longer being maintained, [even for severe security issues](http://guides.rubyonrails.org/maintenance_policy.html). The last 3.1.x release, [was 3 years ago](https://rubygems.org/gems/activerecord/versions).

This will also make the Travis CI build run significantly faster, since we can run 5 builds in parallel and this is the 6th build, so it has to wait for all the other Active Record versions to finish before it can start.