### PR TITLE
Fix issue doing recursive import with :on_duplicate_key_update

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -394,7 +394,7 @@ class ActiveRecord::Base
         set_ids_and_mark_clean(models, return_obj)
 
         # if there are auto-save associations on the models we imported that are new, import them as well
-        import_associations(models, options) if options[:recursive]
+        import_associations(models, options.dup) if options[:recursive]
       end
 
       return_obj
@@ -515,6 +515,9 @@ class ActiveRecord::Base
       #    should probably take a hash to associations to follow.
       associated_objects_by_class = {}
       models.each { |model| find_associated_objects_for_import(associated_objects_by_class, model) }
+
+      # :on_duplicate_key_update not supported for associations
+      options.delete(:on_duplicate_key_update)
 
       associated_objects_by_class.each_pair do |class_name, associations|
         associations.each_pair do |association_name, associated_records|

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -279,6 +279,19 @@ def should_support_postgresql_upsert_functionality
           should_update_updated_at_on_timestamp_columns
         end
       end
+
+      context "with recursive: true" do
+        let(:new_topics) { Build(1, :topic_with_book) }
+
+        it "imports objects with associations" do
+          assert_difference "Topic.count", +1 do
+            Topic.import new_topics, recursive: true, on_duplicate_key_update: [:updated_at], validate: false
+            new_topics.each do |topic|
+              assert_not_nil topic.id
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Only use :on_duplicate_key_update option when importing top level models. Fixes #249.