### PR TITLE
Fix issues running tests for AR 4.0 and 4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 
 version = ENV['AR_VERSION'] || "4.2"
 
-if version > "4.0"
+if version >= "4.0"
   gem "minitest"
 else
   gem "test-unit"

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,3 +1,3 @@
 platforms :ruby do
-  gem 'activerecord', '~> 4.0'
+  gem 'activerecord', '~> 4.0.0'
 end

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,3 +1,3 @@
 platforms :ruby do
-  gem 'activerecord', '~> 4.1'
+  gem 'activerecord', '~> 4.1.0'
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,3 +1,3 @@
 platforms :ruby do
-  gem 'activerecord', '~> 4.2'
+  gem 'activerecord', '~> 4.2.0'
 end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -583,9 +583,12 @@ class ActiveRecord::Base
           elsif column
             if respond_to?(:type_caster) && type_caster.respond_to?(:type_cast_for_database) # Rails 5.0 and higher
               connection_memo.quote(type_caster.type_cast_for_database(column.name, val))
-            elsif column.respond_to?(:type_cast_from_user)                      # Rails 4.2 and higher
+            elsif column.respond_to?(:type_cast_from_user)                                   # Rails 4.2 and higher
               connection_memo.quote(column.type_cast_from_user(val), column)
-            else                                                                # Rails 3.1, 3.2, and 4.1
+            else                                                                             # Rails 3.1, 3.2, 4.0 and 4.1
+              if serialized_attributes.include?(column.name)
+                val = serialized_attributes[column.name].dump(val)
+              end
               connection_memo.quote(column.type_cast(val), column)
             end
           end

--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -44,9 +44,11 @@ module ActiveRecord # :nodoc:
         instance.instance_variable_set :@attributes, matched_instance.instance_variable_get(:@attributes)
 
         if instance.respond_to?(:clear_changes_information)
-          instance.clear_changes_information                  # Rails 4.1 and higher
+          instance.clear_changes_information                      # Rails 4.2 and higher
         else
-          instance.changed_attributes.clear                   # Rails 3.1, 3.2
+          instance.instance_variable_set :@attributes_cache, {}   # Rails 4.0, 4.1
+          instance.changed_attributes.clear                       # Rails 3.1, 3.2
+          instance.previous_changes.clear
         end
 
         # Since the instance now accurately reflects the record in

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -267,11 +267,13 @@ describe "#import" do
   end
 
   context "ActiveRecord timestamps" do
+    let(:time) { Chronic.parse("5 minutes ago")  }
+
     context "when the timestamps columns are present" do
       setup do
         @existing_book = Book.create(title: "Fell", author_name: "Curry", publisher: "Bayer", created_at: 2.years.ago.utc, created_on: 2.years.ago.utc)
         ActiveRecord::Base.default_timezone = :utc
-        Timecop.freeze Chronic.parse("5 minutes ago") do
+        Timecop.freeze(time) do
           assert_difference "Book.count", +2 do
             Book.import %w(title author_name publisher created_at created_on), [["LDAP", "Big Bird", "Del Rey", nil, nil], [@existing_book.title, @existing_book.author_name, @existing_book.publisher, @existing_book.created_at, @existing_book.created_on]]
           end
@@ -280,11 +282,11 @@ describe "#import" do
       end
 
       it "should set the created_at column for new records"  do
-        assert_equal 5.minutes.ago.utc.strftime("%H:%M"), @new_book.created_at.strftime("%H:%M")
+        assert_in_delta time.to_i, @new_book.created_at.to_i, 1.second
       end
 
       it "should set the created_on column for new records" do
-        assert_equal 5.minutes.ago.utc.strftime("%H:%M"), @new_book.created_on.strftime("%H:%M")
+        assert_in_delta time.to_i, @new_book.created_on.to_i, 1.second
       end
 
       it "should not set the created_at column for existing records"  do
@@ -296,17 +298,15 @@ describe "#import" do
       end
 
       it "should set the updated_at column for new records" do
-        assert_equal 5.minutes.ago.utc.strftime("%H:%M"), @new_book.updated_at.strftime("%H:%M")
+        assert_in_delta time.to_i, @new_book.updated_at.to_i, 1.second
       end
 
       it "should set the updated_on column for new records" do
-        assert_equal 5.minutes.ago.utc.strftime("%H:%M"), @new_book.updated_on.strftime("%H:%M")
+        assert_in_delta time.to_i, @new_book.updated_on.to_i, 1.second
       end
     end
 
     context "when a custom time zone is set" do
-      let(:time) { Chronic.parse("5 minutes ago")  }
-
       setup do
         Timecop.freeze(time) do
           assert_difference "Book.count", +1 do

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -447,12 +447,13 @@ describe "#import" do
       assert_equal({ a: :b }, Widget.find_by_w_id(1).data)
     end
 
-    requires_active_record_version ">= 4" do
+    if ENV['AR_VERSION'].to_f >= 3.1
+      let(:data) { { a: :b } }
       it "imports values for serialized JSON fields" do
         assert_difference "Widget.unscoped.count", +1 do
-          Widget.import [:w_id, :json_data], [[9, { a: :b }]]
+          Widget.import [:w_id, :json_data], [[9, data]]
         end
-        assert_equal({ a: :b }.as_json, Widget.find_by_w_id(9).json_data)
+        assert_equal(data.as_json, Widget.find_by_w_id(9).json_data)
       end
     end
   end

--- a/test/support/active_support/test_case_extensions.rb
+++ b/test/support/active_support/test_case_extensions.rb
@@ -4,7 +4,7 @@ class ActiveSupport::TestCase
 
   class << self
     def requires_active_record_version(version_string, &blk)
-      return unless Gem::Dependency.new("expected", version_string).match?("actual", ActiveRecord::VERSION::STRING)
+      return unless Gem::Dependency.new('', version_string).match?('', ActiveRecord::VERSION::STRING)
       instance_eval(&blk)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require "active_record"
 require "active_record/fixtures"
 require "active_support/test_case"
 
-if ActiveSupport::VERSION::STRING < "4.1"
+if ActiveSupport::VERSION::STRING < "4.0"
   require 'test/unit'
 else
   require 'active_support/testing/autorun'


### PR DESCRIPTION
Tests were only running for latest AR 4.2 because the version specifier wasn't to the patch level.

Once tests were running an issue with :synchronize showed up for AR 4.0 and 4.1. This PR incorporates the fix in #176.

Also found that tests for serialization weren't running and JSON serialization was failing on AR < 4.2. Fixes #211.