### PR TITLE
Improve performance of importing models with validations

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -350,12 +350,7 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
           column_names.map do |name|
-            name = name.to_s
-            if respond_to?(:defined_enums) && defined_enums.key?(name) # ActiveRecord 5
-              model.read_attribute(name)
-            else
-              model.read_attribute_before_type_cast(name)
-            end
+            model.read_attribute_before_type_cast(name.to_s)
           end
           # end
         end
@@ -387,7 +382,19 @@ class ActiveRecord::Base
       end
 
       return_obj = if is_validating
-        import_with_validations( column_names, array_of_attributes, options )
+        if models
+          import_with_validations( column_names, array_of_attributes, options ) do |failed|
+            models.each_with_index do |model, i|
+              model = model.dup if options[:recursive]
+              next if model.valid?(options[:validate_with_context])
+              model.send(:raise_record_invalid) if options[:raise_error]
+              array_of_attributes[i] = nil
+              failed << model
+            end
+          end
+        else
+          import_with_validations( column_names, array_of_attributes, options )
+        end
       else
         (num_inserts, ids) = import_without_validations_or_callbacks( column_names, array_of_attributes, options )
         ActiveRecord::Import::Result.new([], num_inserts, ids)
@@ -424,21 +431,24 @@ class ActiveRecord::Base
     def import_with_validations( column_names, array_of_attributes, options = {} )
       failed_instances = []
 
-      # create instances for each of our column/value sets
-      arr = validations_array_for_column_names_and_attributes( column_names, array_of_attributes )
+      if block_given?
+        yield failed_instances
+      else
+        # create instances for each of our column/value sets
+        arr = validations_array_for_column_names_and_attributes( column_names, array_of_attributes )
 
-      # keep track of the instance and the position it is currently at. if this fails
-      # validation we'll use the index to remove it from the array_of_attributes
-      arr.each_with_index do |hsh, i|
-        instance = new do |model|
+        # keep track of the instance and the position it is currently at. if this fails
+        # validation we'll use the index to remove it from the array_of_attributes
+        model = new
+        arr.each_with_index do |hsh, i|
           hsh.each_pair { |k, v| model[k] = v }
+          next if model.valid?(options[:validate_with_context])
+          raise(ActiveRecord::RecordInvalid, model) if options[:raise_error]
+          array_of_attributes[i] = nil
+          failed_instances << model.dup
         end
-
-        next if instance.valid?(options[:validate_with_context])
-        raise(ActiveRecord::RecordInvalid, instance) if options[:raise_error]
-        array_of_attributes[i] = nil
-        failed_instances << instance
       end
+
       array_of_attributes.compact!
 
       num_inserts, ids = if array_of_attributes.empty? || options[:all_or_none] && failed_instances.any?
@@ -636,9 +646,7 @@ class ActiveRecord::Base
 
     # Returns an Array of Hashes for the passed in +column_names+ and +array_of_attributes+.
     def validations_array_for_column_names_and_attributes( column_names, array_of_attributes ) # :nodoc:
-      array_of_attributes.map do |attributes|
-        Hash[attributes.each_with_index.map { |attr, c| [column_names[c], attr] }]
-      end
+      array_of_attributes.map { |values| Hash[column_names.zip(values)] }
     end
   end
 end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -451,6 +451,25 @@ describe "#import" do
     end
   end
 
+  context 'When importing arrays of values with Enum fields' do
+    let(:columns) { [:author_name, :title, :status] }
+    let(:values) { [['Author #1', 'Book #1', 0], ['Author #2', 'Book #2', 1]] }
+
+    it 'should be able to import enum fields' do
+      Book.delete_all if Book.count > 0
+      Book.import columns, values
+      assert_equal 2, Book.count
+
+      if ENV['AR_VERSION'].to_i >= 5.0
+        assert_equal 'draft', Book.first.read_attribute('status')
+        assert_equal 'published', Book.last.read_attribute('status')
+      else
+        assert_equal 0, Book.first.read_attribute('status')
+        assert_equal 1, Book.last.read_attribute('status')
+      end
+    end
+  end
+
   describe "importing when model has default_scope" do
     it "doesn't import the default scope values" do
       assert_difference "Widget.unscoped.count", +2 do


### PR DESCRIPTION
Currently, when validating models on import, the models are converted to arrays of values and then are reinitialized as models to call `valid?` It seems unnecessary to do this extra reinitialization step. Inspired by #118.

Running the MySQL benchmarks on my laptop shows a 2x performance increase (over previous implementation) for importing models with validations.