### PR TITLE
Prevent :on_duplicate_key_ignore being used when :recursive enabled

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -47,7 +47,10 @@ module ActiveRecord::Import::AbstractAdapter
 
       if supports_on_duplicate_key_update?
         if options[:on_duplicate_key_ignore] && respond_to?(:sql_for_on_duplicate_key_ignore)
-          post_sql_statements << sql_for_on_duplicate_key_ignore( table_name, options[:on_duplicate_key_ignore] )
+          # Options :recursive and :on_duplicate_key_ignore are mutually exclusive
+          unless options[:recursive]
+            post_sql_statements << sql_for_on_duplicate_key_ignore( table_name, options[:on_duplicate_key_ignore] )
+          end
         elsif options[:on_duplicate_key_update]
           post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update] )
         end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -168,7 +168,8 @@ class ActiveRecord::Base
     # * +ignore+ - true|false, tells import to use MySQL's INSERT IGNORE
     #    to discard records that contain duplicate keys.
     # * +on_duplicate_key_ignore+ - true|false, tells import to use
-    #    Postgres 9.5+ ON CONFLICT DO NOTHING.
+    #    Postgres 9.5+ ON CONFLICT DO NOTHING. Cannot be enabled on a
+    #    recursive import.
     # * +on_duplicate_key_update+ - an Array or Hash, tells import to
     #    use MySQL's ON DUPLICATE KEY UPDATE or Postgres 9.5+ ON CONFLICT
     #    DO UPDATE ability. See On Duplicate Key Update below.

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -164,28 +164,32 @@ def should_support_postgresql_upsert_functionality
       let(:values) { [[99, "Book", "John Doe", "john@doe.com", 17]] }
       let(:updated_values) { [[99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57]] }
 
-      macro(:perform_import) do |*opts|
-        Topic.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_ignore: value, validate: false)
-      end
-
       setup do
         Topic.import columns, values, validate: false
-        @topic = Topic.find 99
       end
 
-      context "using true" do
-        let(:value) { true }
-        should_not_update_updated_at_on_timestamp_columns
+      it "should not update any records" do
+        result = Topic.import columns, updated_values, on_duplicate_key_ignore: true, validate: false
+        assert_equal [], result.ids
+      end
+    end
+
+    context "with :on_duplicate_key_ignore and :recursive enabled" do
+      let(:new_topic) { Build(1, :topic_with_book) }
+      let(:mixed_topics) { Build(1, :topic_with_book) + new_topic + Build(1, :topic_with_book) }
+
+      setup do
+        Topic.import new_topic, recursive: true
       end
 
-      context "using hash with :conflict_target" do
-        let(:value) { { conflict_target: :id } }
-        should_not_update_updated_at_on_timestamp_columns
-      end
-
-      context "using hash with :constraint_target" do
-        let(:value) { { constraint_name: :topics_pkey } }
-        should_not_update_updated_at_on_timestamp_columns
+      # Recursive import depends on the primary keys of the parent model being returned
+      # on insert. With on_duplicate_key_ignore enabled, not all ids will be returned
+      # and it is possible that a model will be assigned the wrong id and then its children
+      # would be associated with the wrong parent.
+      it ":on_duplicate_key_ignore is ignored" do
+        assert_raise ActiveRecord::RecordNotUnique do
+          Topic.import mixed_topics, recursive: true, on_duplicate_key_ignore: true
+        end
       end
     end
 

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -5,65 +5,76 @@ def should_support_basic_on_duplicate_key_update
     macro(:perform_import) { raise "supply your own #perform_import in a context below" }
     macro(:updated_topic) { Topic.find(@topic.id) }
 
-    context "with :on_duplicate_key_update and validation checks turned off" do
-      asssertion_group(:should_support_on_duplicate_key_update) do
-        should_not_update_fields_not_mentioned
-        should_update_foreign_keys
-        should_not_update_created_at_on_timestamp_columns
-        should_update_updated_at_on_timestamp_columns
+    context "with :on_duplicate_key_update" do
+      describe "argument safety" do
+        it "should not modify the passed in :on_duplicate_key_update columns array" do
+          assert_nothing_raised do
+            columns = %w(title author_name).freeze
+            Topic.import columns, [%w(foo, bar)], on_duplicate_key_update: columns
+          end
+        end
       end
 
-      let(:columns) { %w( id title author_name author_email_address parent_id ) }
-      let(:values) { [[99, "Book", "John Doe", "john@doe.com", 17]] }
-      let(:updated_values) { [[99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57]] }
+      context "with validation checks turned off" do
+        asssertion_group(:should_support_on_duplicate_key_update) do
+          should_not_update_fields_not_mentioned
+          should_update_foreign_keys
+          should_not_update_created_at_on_timestamp_columns
+          should_update_updated_at_on_timestamp_columns
+        end
 
-      macro(:perform_import) do |*opts|
-        Topic.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_update: update_columns, validate: false)
+        let(:columns) { %w( id title author_name author_email_address parent_id ) }
+        let(:values) { [[99, "Book", "John Doe", "john@doe.com", 17]] }
+        let(:updated_values) { [[99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57]] }
+
+        macro(:perform_import) do |*opts|
+          Topic.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_update: update_columns, validate: false)
+        end
+
+        setup do
+          Topic.import columns, values, validate: false
+          @topic = Topic.find 99
+        end
+
+        context "using an empty array" do
+          let(:update_columns) { [] }
+          should_not_update_fields_not_mentioned
+          should_update_updated_at_on_timestamp_columns
+        end
+
+        context "using string column names" do
+          let(:update_columns) { %w(title author_email_address parent_id) }
+          should_support_on_duplicate_key_update
+          should_update_fields_mentioned
+        end
+
+        context "using symbol column names" do
+          let(:update_columns) { [:title, :author_email_address, :parent_id] }
+          should_support_on_duplicate_key_update
+          should_update_fields_mentioned
+        end
       end
 
-      setup do
-        Topic.import columns, values, validate: false
-        @topic = Topic.find 99
-      end
+      context "with a table that has a non-standard primary key" do
+        let(:columns) { [:promotion_id, :code] }
+        let(:values) { [[1, 'DISCOUNT1']] }
+        let(:updated_values) { [[1, 'DISCOUNT2']] }
+        let(:update_columns) { [:code] }
 
-      context "using an empty array" do
-        let(:update_columns) { [] }
-        should_not_update_fields_not_mentioned
-        should_update_updated_at_on_timestamp_columns
-      end
+        macro(:perform_import) do |*opts|
+          Promotion.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_update: update_columns, validate: false)
+        end
+        macro(:updated_promotion) { Promotion.find(@promotion.promotion_id) }
 
-      context "using string column names" do
-        let(:update_columns) { %w(title author_email_address parent_id) }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
+        setup do
+          Promotion.import columns, values, validate: false
+          @promotion = Promotion.find 1
+        end
 
-      context "using symbol column names" do
-        let(:update_columns) { [:title, :author_email_address, :parent_id] }
-        should_support_on_duplicate_key_update
-        should_update_fields_mentioned
-      end
-    end
-
-    context "with a table that has a non-standard primary key" do
-      let(:columns) { [:promotion_id, :code] }
-      let(:values) { [[1, 'DISCOUNT1']] }
-      let(:updated_values) { [[1, 'DISCOUNT2']] }
-      let(:update_columns) { [:code] }
-
-      macro(:perform_import) do |*opts|
-        Promotion.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_update: update_columns, validate: false)
-      end
-      macro(:updated_promotion) { Promotion.find(@promotion.promotion_id) }
-
-      setup do
-        Promotion.import columns, values, validate: false
-        @promotion = Promotion.find 1
-      end
-
-      it "should update specified columns" do
-        perform_import
-        assert_equal 'DISCOUNT2', updated_promotion.code
+        it "should update specified columns" do
+          perform_import
+          assert_equal 'DISCOUNT2', updated_promotion.code
+        end
       end
     end
 


### PR DESCRIPTION
Recursive import depends on the primary keys of the parent model being returned, but :on_duplicate_key_ignore doesn't return ids for duplicate records. It is possible then, that a model will be assigned the wrong id and its children would be associated with the wrong parent.

Fixes #267.