### PR TITLE
Only attempt recursive import when passed array of models

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -418,7 +418,7 @@ class ActiveRecord::Base
       return_obj.num_inserts = 0 if return_obj.num_inserts.nil?
 
       # if we have ids, then set the id on the models and mark the models as clean.
-      if support_setting_primary_key_of_imported_objects?
+      if models && support_setting_primary_key_of_imported_objects?
         set_ids_and_mark_clean(models, return_obj)
 
         # if there are auto-save associations on the models we imported that are new, import them as well
@@ -550,6 +550,7 @@ class ActiveRecord::Base
       # notes:
       #    does not handle associations that reference themselves
       #    should probably take a hash to associations to follow.
+      return if models.nil?
       associated_objects_by_class = {}
       models.each { |model| find_associated_objects_for_import(associated_objects_by_class, model) }
 

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -281,6 +281,12 @@ describe "#import" do
       Topic.import [:id, :author_name, :title], [[99, "Bob Jones", "Topic 99"]]
       assert_equal 99, Topic.last.id
     end
+
+    it "ignores the recursive option" do
+      assert_difference "Topic.count", +1 do
+        Topic.import [:author_name, :title], [["David Chelimsky", "The RSpec Book"]], recursive: true
+      end
+    end
   end
 
   context "ActiveRecord timestamps" do


### PR DESCRIPTION
Prevents a `NoMethodError: undefined method 'each' for nil:NilClass` if :recursive option was erroneously set when importing with an array of columns and an array of values.

Instead the :recursive option is ignored and the import is completed.