### PR TITLE
Added no_returning option for Postgres to insert without RETURNING clause

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -26,7 +26,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
   end
 
   def post_sql_statements( table_name, options ) # :nodoc:
-    if options[:primary_key].blank?
+    if options[:no_returning] || options[:primary_key].blank?
       super(table_name, options)
     else
       super(table_name, options) << "RETURNING #{options[:primary_key]}"

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -147,6 +147,20 @@ def should_support_postgresql_import_functionality
         end
       end
     end
+
+    describe "no_returning" do
+      let(:books) { [Book.new(author_name: "foo", title: "bar")] }
+
+      it "creates records" do
+        assert_difference "Book.count", +1 do
+          Book.import books, no_returning: true
+        end
+      end
+
+      it "returns no ids" do
+        assert_equal [], Book.import(books, no_returning: true).ids
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Motivation for this PR: enable import without `RETURNING` clause (right now for every INSERT statement `RETURNING` clause is applied). This will allow to use Postgres rules for insertion, for example the rule to simply ignore all duplications inside INSERT statement.

Right now if we have smth like this in DB (Postgres younger than 9.5)

~~~
CREATE OR REPLACE RULE events_duplicate_ignore AS ON insert TO events
  WHERE EXISTS(
    SELECT 1
    FROM events
    WHERE (mask)=(NEW.mask)
  )
  DO INSTEAD NOTHING;
~~~

and try to insert duplicate we'll have an error `ActiveRecord::StatementInvalid: PG::FeatureNotSupported: ERROR: cannot perform INSERT RETURNING on relation "events" HINT: You need an unconditional ON INSERT DO INSTEAD rule with a RETURNING clause.`