### PR TITLE
Fix that array_attributes is unintentionally modified

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -365,13 +365,13 @@ class ActiveRecord::Base
         # supports 2-element array and array
       elsif args.size == 2 && args.first.is_a?( Array ) && args.last.is_a?( Array )
         column_names, array_of_attributes = args
+        array_of_attributes = array_of_attributes.map(&:dup)
       else
         raise ArgumentError, "Invalid arguments!"
       end
 
       # dup the passed in array so we don't modify it unintentionally
       column_names = column_names.dup
-      array_of_attributes = array_of_attributes.dup
 
       # Force the primary key col into the insert if it's not
       # on the list and we are using a sequence and stuff a nil


### PR DESCRIPTION
When `#import` takes `Array, Array<Array>` argumentes, those arrays are interpreted as column_names and array_of_attributes. Those arrays were dupped but attributes are not dupped.
Following code uses `#<<` to destructively modify the attributes array.
As a result, elements of the second argument may change after `#import`.

This problem is fatal when retrying like:

```ruby
attributes = ...
begin
  FooModel.import(columns, attributes, timestamp: true, validate: true)
rescue => e
  if can_retry?(e)
    retry
  end
end
```

Because the length of elements of `attributes` and the length of columns mismatch on retry, retry fails.

This patch fix the problem by sophisticating `#dup` mechanism.
When attributes are instances of `ActiveRecord::Base`, array_of_attributes is newly constructed Array of Array, so dup is not necessary.
Otherwise, attributes are arrays, so `dup` each of them. Because `#map` returns a new array, dup to the container is not necessary.