### PR TITLE
Upgrade seamless_database_pool to support AR 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ platforms :ruby do
   gem "mysql2",                 "~> 0.3.0"
   gem "pg",                     "~> 0.9"
   gem "sqlite3",                "~> 1.3.10"
-  gem "seamless_database_pool", "~> 1.0.13"
+  gem "seamless_database_pool", "~> 1.0.18"
 end
 
 platforms :jruby do

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -15,6 +15,7 @@ mysql2spatial:
 seamless_database_pool:
   <<: *common
   adapter: seamless_database_pool
+  prepared_statements: false
   pool_adapter: mysql2
   master:
     host: localhost

--- a/test/travis/database.yml
+++ b/test/travis/database.yml
@@ -15,6 +15,7 @@ mysql2spatial:
 seamless_database_pool:
   <<: *common
   adapter: seamless_database_pool
+  prepared_statements: false
   pool_adapter: mysql2
   master:
     host: localhost


### PR DESCRIPTION
This will resolve the failing seamless_database_pool tests for AR 5.0. Note that AR 3.1 is not supported by the seamless_database_pool gem as of version 1.0.18 (which adds AR 5.0RC1 support).