### PR TITLE
Raise ArgumentError if no conflict_target available

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -113,15 +113,16 @@ module ActiveRecord::Import::PostgreSQLAdapter
   def sql_for_conflict_target( args = {} )
     constraint_name = args[:constraint_name]
     conflict_target = args[:conflict_target]
-    if constraint_name
+    if constraint_name.present?
       "ON CONSTRAINT #{constraint_name} "
-    elsif conflict_target
-      '(' << Array( conflict_target ).join( ', ' ) << ') '
+    elsif conflict_target.present?
+      '(' << Array( conflict_target ).reject( &:empty? ).join( ', ' ) << ') '
     end
   end
 
   def sql_for_default_conflict_target( table_name )
-    "(#{primary_key( table_name )}) "
+    conflict_target = primary_key( table_name )
+    "(#{conflict_target}) " if conflict_target
   end
 
   # Return true if the statement is a duplicate key record error


### PR DESCRIPTION
If no conflict target is specified, and a table does not have a primary key, an `ArgumentError` is raised with the message:

```
Expected :conflict_target or :constraint_name to be specified
```

Currently, a `ActiveRecord::StatementInvalid` error is raised because the SQL is generated without any conflict target value:

```
ON CONFLICT () DO UPDATE SET
```