### PR TITLE
Fix undefined method `raise_record_invalid' on Rails 5.0

### DIFF
--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,3 +1,7 @@
 platforms :ruby do
   gem 'activerecord', '~> 4.2.0'
 end
+
+platforms :jruby do
+  gem 'activerecord', '~> 4.2.0'
+end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -394,7 +394,11 @@ class ActiveRecord::Base
             models.each_with_index do |model, i|
               model = model.dup if options[:recursive]
               next if model.valid?(options[:validate_with_context])
-              model.send(:raise_record_invalid) if options[:raise_error]
+              if options[:raise_error] && model.respond_to?(:raise_validation_error, true) # Rails 5.0 and higher
+                model.send(:raise_validation_error)
+              elsif options[:raise_error] # Rails 3.2, 4.0, 4.1 and 4.2
+                model.send(:raise_record_invalid)
+              end
               array_of_attributes[i] = nil
               failed << model
             end


### PR DESCRIPTION
Fix NoMethodError: undefined method `raise_record_invalid'.

Method name changed 'raise_record_invalid' to 'raise_validation_error' in Rails 5.0.
https://github.com/rails/rails/commit/830b7041f213669c3877edf459ef83a31c84cc4d