### PR TITLE
Improve test coverage for serailzed attributes

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -485,11 +485,25 @@ describe "#import" do
   end
 
   describe "importing serialized fields" do
-    it "imports values for serialized fields" do
+    it "imports values for serialized Hash fields" do
       assert_difference "Widget.unscoped.count", +1 do
         Widget.import [:w_id, :data], [[1, { a: :b }]]
       end
       assert_equal({ a: :b }, Widget.find_by_w_id(1).data)
+    end
+
+    it "imports values for serialized fields" do
+      assert_difference "Widget.unscoped.count", +1 do
+        Widget.import [:w_id, :unspecified_data], [[1, { a: :b }]]
+      end
+      assert_equal({ a: :b }, Widget.find_by_w_id(1).unspecified_data)
+    end
+
+    it "imports values for custom coder" do
+      assert_difference "Widget.unscoped.count", +1 do
+        Widget.import [:w_id, :custom_data], [[1, { a: :b }]]
+      end
+      assert_equal({ a: :b }, Widget.find_by_w_id(1).custom_data)
     end
 
     if ENV['AR_VERSION'].to_f >= 3.1

--- a/test/models/widget.rb
+++ b/test/models/widget.rb
@@ -1,3 +1,17 @@
+class CustomCoder
+  def load(value)
+    if value.nil?
+      {}
+    else
+      YAML.load(value)
+    end
+  end
+
+  def dump(value)
+    YAML.dump(value)
+  end
+end
+
 class Widget < ActiveRecord::Base
   self.primary_key = :w_id
 
@@ -5,4 +19,6 @@ class Widget < ActiveRecord::Base
 
   serialize :data, Hash
   serialize :json_data, JSON
+  serialize :unspecified_data
+  serialize :custom_data, CustomCoder.new
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define do
     t.boolean :active, default: false
     t.text :data
     t.text :json_data
+    t.text :unspecified_data
+    t.text :custom_data
   end
 
   create_table :promotions, primary_key: :promotion_id, force: :cascade do |t|


### PR DESCRIPTION
While trying to track down bug between activerecord-import and another gem wrote more test coverage to rule out that issue was caused by activerecord-import. This pull requests only adds more test coverage.