### PR TITLE
Bypass uniqueness validation on import

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -159,6 +159,13 @@ describe "#import" do
         end
       end
 
+      it "should ignore uniqueness validators" do
+        Topic.import columns, valid_values, validate: true
+        assert_difference "Topic.count", +2 do
+          Topic.import columns, valid_values, validate: true
+        end
+      end
+
       it "should not import invalid data" do
         assert_no_difference "Topic.count" do
           Topic.import columns, invalid_values, validate: true

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -1,6 +1,7 @@
 class Topic < ActiveRecord::Base
   validates_presence_of :author_name
   validates :title, numericality: { only_integer: true }, on: :context_test
+  validates :title, uniqueness: true
 
   has_many :books, inverse_of: :topic
   belongs_to :parent, class_name: "Topic"

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -176,7 +176,7 @@ def should_support_postgresql_upsert_functionality
       # would be associated with the wrong parent.
       it ":on_duplicate_key_ignore is ignored" do
         assert_raise ActiveRecord::RecordNotUnique do
-          Topic.import mixed_topics, recursive: true, on_duplicate_key_ignore: true
+          Topic.import mixed_topics, recursive: true, on_duplicate_key_ignore: true, validate: false
         end
       end
     end


### PR DESCRIPTION
Improves performance of importing with validations when models have uniqueness validators (See #228). Uniqueness cannot be guaranteed if there are duplicate values in the batch. Race conditions are also possible, so the only way to really preserve uniqueness is by using a database index.

With uniqueness validation removed, model validation could be done in combination with `:on_duplicate_key_update`, `:on_duplicate_key_ignore`, or `:ignore` for databases that support those options.

Just looking for feedback at this point, thanks!
