### PR TITLE
Same primary key on recursive issue resolved

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -332,8 +332,9 @@ class ActiveRecord::Base
     end
 
     def import_helper( *args )
-      options = { validate: true, timestamps: true, primary_key: primary_key }
+      options = { validate: true, timestamps: true }
       options.merge!( args.pop ) if args.last.is_a? Hash
+      options[:primary_key] = primary_key
 
       # Don't modify incoming arguments
       if options[:on_duplicate_key_update]

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -334,6 +334,7 @@ class ActiveRecord::Base
     def import_helper( *args )
       options = { validate: true, timestamps: true }
       options.merge!( args.pop ) if args.last.is_a? Hash
+      # making sure that current model's primary key is used
       options[:primary_key] = primary_key
 
       # Don't modify incoming arguments

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define do
     t.datetime :updated_at
   end
 
-  create_table :end_notes, force: :cascade do |t|
+  create_table :end_notes, primary_key: :end_note_id, force: :cascade do |t|
     t.string :note
     t.integer :book_id, null: false
     t.datetime :created_at


### PR DESCRIPTION
While using recursive option same primary key is used for all activerecords. Which fails when a activerecord has different primary key name or doesn't have one.