### PR TITLE
Updating support for import from a STI subclass with polymorphic associations 

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -582,7 +582,8 @@ class ActiveRecord::Base
           child.public_send("#{association_reflection.foreign_key}=", model.id)
           # For polymorphic associations
           association_reflection.type.try do |type|
-            model_class_name = model.class.superclass.name == "ActiveRecord::Base" ? model.class.name : model.class.superclass.name
+            model_class_name = model.class.superclass.name
+            model_class_name = model.class.name if ["ActiveRecord::Base", "ApplicationRecord"].include? model_class_name
             child.public_send("#{type}=", model_class_name)
           end
         end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -582,9 +582,7 @@ class ActiveRecord::Base
           child.public_send("#{association_reflection.foreign_key}=", model.id)
           # For polymorphic associations
           association_reflection.type.try do |type|
-            model_class_name = model.class.superclass.name
-            model_class_name = model.class.name if ["ActiveRecord::Base", "ApplicationRecord"].include? model_class_name
-            child.public_send("#{type}=", model_class_name)
+            child.public_send("#{type}=", model.class.base_class.name)
           end
         end
         associated_objects_by_class[model.class.name][association_reflection.name].concat changed_objects

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -582,7 +582,8 @@ class ActiveRecord::Base
           child.public_send("#{association_reflection.foreign_key}=", model.id)
           # For polymorphic associations
           association_reflection.type.try do |type|
-            child.public_send("#{type}=", model.class.name)
+            model_class_name = model.class.superclass.name == "ActiveRecord::Base" ? model.class.name : model.class.superclass.name
+            child.public_send("#{type}=", model_class_name)
           end
         end
         associated_objects_by_class[model.class.name][association_reflection.name].concat changed_objects

--- a/test/models/dictionary.rb
+++ b/test/models/dictionary.rb
@@ -1,3 +1,2 @@
 class Dictionary < Book
-
 end

--- a/test/models/dictionary.rb
+++ b/test/models/dictionary.rb
@@ -1,0 +1,3 @@
+class Dictionary < Book
+
+end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define do
     t.integer :topic_id
     t.boolean :for_sale, default: true
     t.integer :status, default: 0
+    t.string :type
   end
 
   create_table :chapters, force: :cascade do |t|

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -48,6 +48,22 @@ def should_support_recursive_import
       end
     end
 
+    it 'imports polymorphic associations from subclass' do
+      discounts = Array.new(1) { |i| Discount.new(amount: i) }
+      dictionaries = Array.new(1) { |i| Dictionary.new(author_name: "Author ##{i}", title: "Book ##{i}") }
+      dictionaries.each do |dictionary|
+        dictionary.discounts << discounts
+      end
+      Dictionary.import dictionaries, recursive: true
+      assert_equal 1, Dictionary.last.discounts.count
+      dictionaries.each do |dictionary|
+        dictionary.discounts.each do |discount|
+          assert_not_nil discount.discountable_id
+          assert_equal 'Book', discount.discountable_type
+        end
+      end
+    end
+
     [{ recursive: false }, {}].each do |import_options|
       it "skips recursion for #{import_options}" do
         assert_difference "Book.count", 0 do


### PR DESCRIPTION
The commits fixes the import a subclass of STI with polymorphic associations. It was getting the model class name to the polymorphic record instead of its parent class name.