### PR TITLE
fix setting returned ids to wrong models

### DIFF
--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -33,8 +33,8 @@ module ActiveRecord::Import::SQLite3Adapter
     value_sets.each do |value_set|
       number_of_inserts += 1
       sql2insert = base_sql + value_set.join( ',' ) + post_sql
-      first_insert_id = insert( sql2insert, *args )
-      last_insert_id = first_insert_id + value_set.size - 1
+      last_insert_id = insert( sql2insert, *args )
+      first_insert_id = last_insert_id - value_set.size + 1
       ids.concat((first_insert_id..last_insert_id).to_a)
     end
 

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -529,7 +529,7 @@ class ActiveRecord::Base
 
     def set_ids_and_mark_clean(models, import_result)
       return if models.nil?
-      models = models - import_result.failed_instances
+      models -= import_result.failed_instances
       import_result.ids.each_with_index do |id, index|
         model = models[index]
         model.id = id.to_i

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -529,6 +529,7 @@ class ActiveRecord::Base
 
     def set_ids_and_mark_clean(models, import_result)
       return if models.nil?
+      models = models - import_result.failed_instances
       import_result.ids.each_with_index do |id, index|
         model = models[index]
         model.id = id.to_i

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -51,6 +51,8 @@ describe "#import" do
     let(:valid_values) { [["LDAP", "Jerry Carter"], ["Rails Recipes", "Chad Fowler"]] }
     let(:valid_values_with_context) { [[1111, "Jerry Carter"], [2222, "Chad Fowler"]] }
     let(:invalid_values) { [["The RSpec Book", ""], ["Agile+UX", ""]] }
+    let(:valid_models) { valid_values.map { |title, author_name| Topic.new(title: title, author_name: author_name) } }
+    let(:invalid_models) { invalid_values.map { |title, author_name| Topic.new(title: title, author_name: author_name) } }
 
     context "with validation checks turned off" do
       it "should import valid data" do
@@ -101,6 +103,16 @@ describe "#import" do
         results = Topic.import columns, invalid_values, validate: true
         assert_equal invalid_values.size, results.failed_instances.size
         results.failed_instances.each { |e| assert_kind_of Topic, e }
+      end
+
+      it "should set ids in valid models if adapter supports setting primary key of imported objects" do
+        if ActiveRecord::Base.support_setting_primary_key_of_imported_objects?
+          results = Topic.import (invalid_models + valid_models), validate: true
+          assert_nil invalid_models[0].id
+          assert_nil invalid_models[1].id
+          assert_equal valid_models[0].id, Topic.first.id
+          assert_equal valid_models[1].id, Topic.second.id
+        end
       end
 
       it "should import valid data when mixed with invalid data" do

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -110,8 +110,8 @@ describe "#import" do
           Topic.import (invalid_models + valid_models), validate: true
           assert_nil invalid_models[0].id
           assert_nil invalid_models[1].id
-          assert_equal valid_models[0].id, Topic.first.id
-          assert_equal valid_models[1].id, Topic.second.id
+          assert_equal valid_models[0].id, Topic.all[0].id
+          assert_equal valid_models[1].id, Topic.all[1].id
         end
       end
 

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -107,7 +107,7 @@ describe "#import" do
 
       it "should set ids in valid models if adapter supports setting primary key of imported objects" do
         if ActiveRecord::Base.support_setting_primary_key_of_imported_objects?
-          results = Topic.import (invalid_models + valid_models), validate: true
+          Topic.import (invalid_models + valid_models), validate: true
           assert_nil invalid_models[0].id
           assert_nil invalid_models[1].id
           assert_equal valid_models[0].id, Topic.first.id


### PR DESCRIPTION
In `support_setting_primary_key_of_imported_objects? == true` adapters like Postgres, `set_ids_and_mark_clean` iterates returned ids and set them to models (include both valid and invalid). It seems that this method should ignore invalid models.