### PR TITLE
Add store accessor support for json, jsonb, and hstore datatypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,13 @@ matrix:
 before_script:
   - mysql -e 'create database activerecord_import_test;'
   - psql -c 'create database activerecord_import_test;' -U postgres
-  - psql -U postgres -c "create extension postgis"
+  - psql activerecord_import_test -c 'create extension if not exists hstore;' -U postgres
+  - psql -c 'create extension if not exists postgis;' -U postgres
+  - psql -c 'create extension if not exists "uuid-ossp";' -U postgres
   - cp test/travis/database.yml test/database.yml
 
 addons:
+  postgresql: "9.4"
   apt:
     sources:
       - travis-ci/sqlite3

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -318,7 +318,7 @@ class ActiveRecord::Base
     # This returns an object which responds to +failed_instances+ and +num_inserts+.
     # * failed_instances - an array of objects that fails validation and were not committed to the database. An empty array if no validation is performed.
     # * num_inserts - the number of insert statements it took to import the data
-    # * ids - the primary keys of the imported ids, if the adpater supports it, otherwise and empty array.
+    # * ids - the primary keys of the imported ids if the adapter supports it, otherwise an empty array.
     def import(*args)
       if args.first.is_a?( Array ) && args.first.first.is_a?(ActiveRecord::Base)
         options = {}
@@ -374,7 +374,11 @@ class ActiveRecord::Base
           # this next line breaks sqlite.so with a segmentation fault
           # if model.new_record? || options[:on_duplicate_key_update]
           column_names.map do |name|
-            model.read_attribute_before_type_cast(name.to_s)
+            if respond_to?(:stored_attributes) && stored_attributes.include?(name.to_sym)
+              model.send(name.to_s)
+            else
+              model.read_attribute_before_type_cast(name.to_s)
+            end
           end
           # end
         end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -555,13 +555,21 @@ describe "#import" do
       assert_equal({ a: :b }, Widget.find_by_w_id(1).custom_data)
     end
 
-    if ENV['AR_VERSION'].to_f >= 3.1
-      let(:data) { { a: :b } }
-      it "imports values for serialized JSON fields" do
-        assert_difference "Widget.unscoped.count", +1 do
-          Widget.import [:w_id, :json_data], [[9, data]]
+    let(:data) { { a: :b } }
+    it "imports values for serialized JSON fields" do
+      assert_difference "Widget.unscoped.count", +1 do
+        Widget.import [:w_id, :json_data], [[9, data]]
+      end
+      assert_equal(data.as_json, Widget.find_by_w_id(9).json_data)
+    end
+
+    context "with a store" do
+      it "imports serialized attributes set using accessors" do
+        vendors = [Vendor.new(name: 'Vendor 1', color: 'blue')]
+        assert_difference "Vendor.count", +1 do
+          Vendor.import vendors
         end
-        assert_equal(data.as_json, Widget.find_by_w_id(9).json_data)
+        assert_equal('blue', Vendor.first.color)
       end
     end
   end

--- a/test/models/vendor.rb
+++ b/test/models/vendor.rb
@@ -1,2 +1,7 @@
 class Vendor < ActiveRecord::Base
+  store :preferences, accessors: [:color], coder: JSON
+
+  store_accessor :data, :size
+  store_accessor :config, :contact
+  store_accessor :settings, :charge_code
 end

--- a/test/postgis/import_test.rb
+++ b/test/postgis/import_test.rb
@@ -2,3 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
 
 should_support_postgresql_import_functionality
+
+if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+  should_support_postgresql_upsert_functionality
+end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -143,4 +143,12 @@ ActiveRecord::Schema.define do
   create_table :questions, force: :cascade do |t|
     t.string :body
   end
+
+  create_table :vendors, force: :cascade do |t|
+    t.string :name, null: true
+    t.text :preferences
+    t.text :data
+    t.text :config
+    t.text :settings
+  end
 end

--- a/test/schema/postgresql_schema.rb
+++ b/test/schema/postgresql_schema.rb
@@ -1,8 +1,29 @@
 ActiveRecord::Schema.define do
+  execute('CREATE extension IF NOT EXISTS "hstore";')
   execute('CREATE extension IF NOT EXISTS "uuid-ossp";')
 
   create_table :vendors, id: :uuid, force: :cascade do |t|
     t.string :name, null: true
+    t.text :preferences
+
+    if t.respond_to?(:json)
+      t.json :data
+    else
+      t.text :data
+    end
+
+    if t.respond_to?(:hstore)
+      t.hstore :config
+    else
+      t.text :config
+    end
+
+    if t.respond_to?(:jsonb)
+      t.jsonb :settings
+    else
+      t.text :settings
+    end
+
     t.datetime :created_at
     t.datetime :updated_at
   end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -74,6 +74,36 @@ def should_support_postgresql_import_functionality
       assert_not_nil vendor.id
     end
   end
+
+  describe "with store accessor fields" do
+    if ENV['AR_VERSION'].to_f >= 4.0
+      it "imports values for json fields" do
+        vendors = [Vendor.new(name: 'Vendor 1', size: 100)]
+        assert_difference "Vendor.count", +1 do
+          Vendor.import vendors
+        end
+        assert_equal(100, Vendor.first.size)
+      end
+
+      it "imports values for hstore fields" do
+        vendors = [Vendor.new(name: 'Vendor 1', contact: 'John Smith')]
+        assert_difference "Vendor.count", +1 do
+          Vendor.import vendors
+        end
+        assert_equal('John Smith', Vendor.first.contact)
+      end
+    end
+
+    if ENV['AR_VERSION'].to_f >= 4.2
+      it "imports values for jsonb fields" do
+        vendors = [Vendor.new(name: 'Vendor 1', charge_code: '12345')]
+        assert_difference "Vendor.count", +1 do
+          Vendor.import vendors
+        end
+        assert_equal('12345', Vendor.first.charge_code)
+      end
+    end
+  end
 end
 
 def should_support_postgresql_upsert_functionality


### PR DESCRIPTION
Add support for setting attributes on serialized fields using store accessor. JSON, JSONB and HSTORE data types require AR 4.0 and up. Stores backed by a text field are supported in Rails 3.2.

Resolves #313, #186 and #150.