### PR TITLE
Add on_duplicate_key_ignore support for MySQL and SQLite

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -23,7 +23,6 @@ module ActiveRecord::Import::AbstractAdapter
       sql = []
       sql << options[:pre_sql] if options[:pre_sql]
       sql << options[:command] if options[:command]
-      sql << "IGNORE" if options[:ignore]
 
       # add keywords like IGNORE or DELAYED
       if options[:keywords].is_a?(Array)
@@ -45,15 +44,8 @@ module ActiveRecord::Import::AbstractAdapter
     def post_sql_statements( table_name, options ) # :nodoc:
       post_sql_statements = []
 
-      if supports_on_duplicate_key_update?
-        if options[:on_duplicate_key_ignore] && respond_to?(:sql_for_on_duplicate_key_ignore)
-          # Options :recursive and :on_duplicate_key_ignore are mutually exclusive
-          unless options[:recursive]
-            post_sql_statements << sql_for_on_duplicate_key_ignore( table_name, options[:on_duplicate_key_ignore] )
-          end
-        elsif options[:on_duplicate_key_update]
-          post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update] )
-        end
+      if supports_on_duplicate_key_update? && options[:on_duplicate_key_update]
+        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update] )
       elsif options[:on_duplicate_key_update]
         logger.warn "Ignoring on_duplicate_key_update because it is not supported by the database."
       end

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -60,6 +60,12 @@ module ActiveRecord::Import::MysqlAdapter
     end
   end
 
+  def pre_sql_statements( options)
+    sql = []
+    sql << "IGNORE" if options[:ignore] || options[:on_duplicate_key_ignore]
+    sql + super
+  end
+
   # Add a column to be updated on duplicate key update
   def add_column_for_on_duplicate_key_update( column, options = {} ) # :nodoc:
     if options.include?(:on_duplicate_key_update)
@@ -68,7 +74,7 @@ module ActiveRecord::Import::MysqlAdapter
       when Array then columns << column.to_sym unless columns.include?(column.to_sym)
       when Hash then columns[column.to_sym] = column.to_sym
       end
-    else
+    elsif !options[:on_duplicate_key_ignore]
       options[:on_duplicate_key_update] = [column.to_sym]
     end
   end

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -34,15 +34,29 @@ module ActiveRecord::Import::SQLite3Adapter
       number_of_inserts += 1
       sql2insert = base_sql + value_set.join( ',' ) + post_sql
       last_insert_id = insert( sql2insert, *args )
-      first_insert_id = last_insert_id - value_set.size + 1
+      first_insert_id = last_insert_id - affected_rows + 1
       ids.concat((first_insert_id..last_insert_id).to_a)
     end
 
     [number_of_inserts, ids]
   end
 
+  def pre_sql_statements( options)
+    sql = []
+    # Options :recursive and :on_duplicate_key_ignore are mutually exclusive
+    if (options[:ignore] || options[:on_duplicate_key_ignore]) && !options[:recursive]
+      sql << "OR IGNORE"
+    end
+    sql + super
+  end
+
   def next_value_for_sequence(sequence_name)
     %{nextval('#{sequence_name}')}
+  end
+
+  def affected_rows
+    result = execute('SELECT changes();')
+    result.first[0]
   end
 
   def support_setting_primary_key_of_imported_objects?

--- a/test/sqlite3/import_test.rb
+++ b/test/sqlite3/import_test.rb
@@ -1,6 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 should_support_recursive_import
+should_support_on_duplicate_key_ignore
 
 describe "#supports_imports?" do
   context "and SQLite is 3.7.11 or higher" do

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -4,6 +4,7 @@ def should_support_mysql_import_functionality
   ActiveRecord::Base.connection.execute "set sql_mode='STRICT_ALL_TABLES'"
 
   should_support_basic_on_duplicate_key_update
+  should_support_on_duplicate_key_ignore
 
   describe "#import" do
     context "with :on_duplicate_key_update and validation checks turned off" do

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -108,6 +108,7 @@ end
 
 def should_support_postgresql_upsert_functionality
   should_support_basic_on_duplicate_key_update
+  should_support_on_duplicate_key_ignore
 
   describe "#import" do
     extend ActiveSupport::TestCase::ImportAssertions

--- a/test/support/shared_examples/on_duplicate_key_ignore.rb
+++ b/test/support/shared_examples/on_duplicate_key_ignore.rb
@@ -1,0 +1,25 @@
+def should_support_on_duplicate_key_ignore
+  describe "#import" do
+    extend ActiveSupport::TestCase::ImportAssertions
+    let(:topic) { Topic.create!(title: "Book", author_name: "John Doe") }
+    let(:topics) { [topic] }
+
+    context "with :on_duplicate_key_ignore" do
+      it "should skip duplicates and continue import" do
+        topics << Topic.new(id: 100, title: "Book 2", author_name: "Jane Doe")
+        assert_difference "Topic.count", +1 do
+          Topic.import topics, on_duplicate_key_ignore: true, validate: false
+        end
+      end
+    end
+
+    context "with :ignore" do
+      it "should skip duplicates and continue import" do
+        topics << Topic.new(id: 100, title: "Book 2", author_name: "Jane Doe")
+        assert_difference "Topic.count", +1 do
+          Topic.import topics, ignore: true, validate: false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
All three supported adapters (Postgres, MySQL, and SQLite) now support either `on_duplicate_key_ignore` or the alias `ignore` to  skip existing records on import.

Requires a primary key or unique index to identify duplicate records.