### PR TITLE
Wrap multiple database queries in transactions

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -39,10 +39,13 @@ module ActiveRecord::Import::MysqlAdapter
       value_sets = ::ActiveRecord::Import::ValueSetsBytesParser.parse(values,
         reserved_bytes: sql_size,
         max_bytes: max)
-      value_sets.each do |value_set|
-        number_of_inserts += 1
-        sql2insert = base_sql + value_set.join( ',' ) + post_sql
-        insert( sql2insert, *args )
+
+      transaction(requires_new: true) do
+        value_sets.each do |value_set|
+          number_of_inserts += 1
+          sql2insert = base_sql + value_set.join( ',' ) + post_sql
+          insert( sql2insert, *args )
+        end
       end
     end
 

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -30,12 +30,14 @@ module ActiveRecord::Import::SQLite3Adapter
     value_sets = ::ActiveRecord::Import::ValueSetsRecordsParser.parse(values,
       max_records: SQLITE_LIMIT_COMPOUND_SELECT)
 
-    value_sets.each do |value_set|
-      number_of_inserts += 1
-      sql2insert = base_sql + value_set.join( ',' ) + post_sql
-      last_insert_id = insert( sql2insert, *args )
-      first_insert_id = last_insert_id - affected_rows + 1
-      ids.concat((first_insert_id..last_insert_id).to_a)
+    transaction(requires_new: true) do
+      value_sets.each do |value_set|
+        number_of_inserts += 1
+        sql2insert = base_sql + value_set.join( ',' ) + post_sql
+        last_insert_id = insert( sql2insert, *args )
+        first_insert_id = last_insert_id - affected_rows + 1
+        ids.concat((first_insert_id..last_insert_id).to_a)
+      end
     end
 
     [number_of_inserts, ids]

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -541,9 +541,11 @@ class ActiveRecord::Base
           ids += result[1]
         end
       else
-        values_sql.each do |values|
-          ids << connection.insert(insert_sql + values)
-          number_inserted += 1
+        transaction(requires_new: true) do
+          values_sql.each do |values|
+            ids << connection.insert(insert_sql + values)
+            number_inserted += 1
+          end
         end
       end
       [number_inserted, ids]


### PR DESCRIPTION
Database adapters (SQLite, MySQL) that potentially break inserts into multiple queries should wrap statements in a transaction for atomicity. This would make it easier to recover from errors.