### PR TITLE
Avoid accessing ActiveRecord::Base.connection directly for multiple databases

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -21,7 +21,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       insert( sql2insert, *args )
     end
 
-    ActiveRecord::Base.connection.query_cache.clear
+    query_cache.clear
 
     [number_of_inserts, ids]
   end


### PR DESCRIPTION
When using multiple databases by extending ActiveRecord::Base, `ActiveRecord::Base.connection` refers wrong connection.

Therefore simply use `self.query_cache` instead of `ActiveRecord::Base.connection.query_cache`.