### PR TITLE
Raise ArgumentError on incorrect usage of nested arrays

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -390,6 +390,11 @@ class ActiveRecord::Base
         return ActiveRecord::Import::Result.new([], 0, [])
         # supports 2-element array and array
       elsif args.size == 2 && args.first.is_a?( Array ) && args.last.is_a?( Array )
+
+        unless args.last.first.is_a?(Array)
+          raise ArgumentError, "Last argument should be a two dimensional array '[[]]'. First element in array was a #{args.last.first.class}"
+        end
+
         column_names, array_of_attributes = args
 
         # dup the passed args so we don't modify unintentionally

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -12,6 +12,11 @@ describe "#import" do
     end
   end
 
+  it "warns you that you're using the library wrong" do
+    error = assert_raise(ArgumentError) { Topic.import %w(title author_name), ['Author #1', 'Book #1', 0] }
+    assert_equal error.message, "Last argument should be a two dimensional array '[[]]'. First element in array was a String"
+  end
+
   it "should not produce an error when importing empty arrays" do
     assert_nothing_raised do
       Topic.import []


### PR DESCRIPTION
Raises an error if the first element in the nested array is not an array
itself.