### PR TITLE
Update Travis build to use Bundler 1.13.7 for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
   include:
     - rvm: jruby-9.0.5.0
       env: AR_VERSION=4.2
+      before_install:
+        - gem uninstall -i /home/travis/.rvm/gems/jruby-9.0.5.0@global bundler
+        - gem install bundler -v 1.13.7 --no-rdoc --no-ri --no-document
+
       script:
         - bundle exec rake test:jdbcsqlite3
         - bundle exec rake test:jdbcmysql

--- a/Gemfile
+++ b/Gemfile
@@ -30,10 +30,6 @@ gem "mocha"
 
 # Debugging
 platforms :jruby do
-  gem "ruby-debug-base", "= 0.10.4"
-end
-
-platforms :jruby, :mri_18 do
   gem "ruby-debug", "= 0.10.4"
 end
 


### PR DESCRIPTION
Work around to fix failing JRuby tests. Apparently Bundler 1.14.1 doesn't work with JRuby 9.0.5.0.