### PR TITLE
Fixed missing quotes when returnings ids in postgresql

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -52,7 +52,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
     unless options[:no_returning] || options[:primary_key].blank?
       primary_key = Array(options[:primary_key])
-      sql << " RETURNING #{primary_key.join(', ')}"
+      sql << " RETURNING \"#{primary_key.join('", "')}\""
     end
 
     sql


### PR DESCRIPTION
Missing quotes cause an error where postgresql can't recognize the columns if their name is not entirely in lowercase letters.