### PR TITLE
Postgresql doesn't recognize column names with capital letters when returning ids.

### DIFF
--- a/test/models/promotion.rb
+++ b/test/models/promotion.rb
@@ -1,3 +1,3 @@
 class Promotion < ActiveRecord::Base
-  self.primary_key = :promotion_id
+  self.primary_key = :Promotion_id
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define do
     t.text :custom_data
   end
 
-  create_table :promotions, primary_key: :promotion_id, force: :cascade do |t|
+  create_table :promotions, primary_key: :Promotion_id, force: :cascade do |t|
     t.string :code
     t.string :description
     t.decimal :discount

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -56,7 +56,7 @@ def should_support_basic_on_duplicate_key_update
       end
 
       context "with a table that has a non-standard primary key" do
-        let(:columns) { [:promotion_id, :code] }
+        let(:columns) { [:Promotion_id, :code] }
         let(:values) { [[1, 'DISCOUNT1']] }
         let(:updated_values) { [[1, 'DISCOUNT2']] }
         let(:update_columns) { [:code] }
@@ -64,7 +64,7 @@ def should_support_basic_on_duplicate_key_update
         macro(:perform_import) do |*opts|
           Promotion.import columns, updated_values, opts.extract_options!.merge(on_duplicate_key_update: update_columns, validate: false)
         end
-        macro(:updated_promotion) { Promotion.find(@promotion.promotion_id) }
+        macro(:updated_promotion) { Promotion.find(@promotion.Promotion_id) }
 
         setup do
           Promotion.import columns, values, validate: false


### PR DESCRIPTION
This is caused by missing quotes around the id values when returning them.

I changed promotion_id from the promotions table to Promotion_id to trigger the error, is this enough?