### PR TITLE
Add options single insert

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Import::MysqlAdapter
 
   # +sql+ can be a single string or an array. If it is an array all
   # elements that are in position >= 1 will be appended to the final SQL.
-  def insert_many( sql, values, _options = {}, *args ) # :nodoc:
+  def insert_many( sql, values, options = {}, *args ) # :nodoc:
     # the number of inserts default
     number_of_inserts = 0
 
@@ -31,7 +31,7 @@ module ActiveRecord::Import::MysqlAdapter
     max = max_allowed_packet
 
     # if we can insert it all as one statement
-    if NO_MAX_PACKET == max || total_bytes <= max
+    if NO_MAX_PACKET == max || total_bytes <= max || options[:single_insert]
       number_of_inserts += 1
       sql2insert = base_sql + values.join( ',' ) + post_sql
       insert( sql2insert, *args )

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -86,8 +86,11 @@ def should_support_mysql_import_functionality
     describe "single_insert" do
       let(:values) do
         # generate "big" data to go above the default mysql max_allowed_packet limit
+        max_allow_packet = Car.connection.execute("SHOW VARIABLES like 'max_allowed_packet';" ).to_a[0][1].to_i
         value = 'long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet'.freeze
-        Array.new(20_000) do
+
+        nb_values = (max_allow_packet / value.size) + 1
+        Array.new(nb_values) do
           [value]
         end
       end

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -87,7 +87,7 @@ def should_support_mysql_import_functionality
       let(:values) do
         # generate "big" data to go above the default mysql max_allowed_packet limit
         value = 'long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet_long_name_to_increase_size_of_the_packet'.freeze
-        20000.times.map do
+        Array.new(20_000) do
           [value]
         end
       end


### PR DESCRIPTION
#### Description ####

Add an option to force doing a single insert so we can ensure the import will be atomic without transaction or will raise an error.
