### PR TITLE
remove numerical primary_key as well

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -412,7 +412,7 @@ class ActiveRecord::Base
           column_names = self.column_names.dup
         end
 
-        if models.first.id.nil? && column_names.include?(primary_key) && columns_hash[primary_key].type == :uuid
+        if models.first.id.nil? && column_names.include?(primary_key) && [:integer, :uuid].include?(columns_hash[primary_key].type)
           column_names.delete(primary_key)
         end
 


### PR DESCRIPTION
I am hitting this bug, after switching from MySQL to PostgreSQL

` ActiveRecord::StatementInvalid: PG::NotNullViolation: ERROR: null value in column "id" violates not-null constraint DETAIL: Failing row contains (null, ...`

So I am thinking maybe we should remove the primary key column when its numerical as well.

I'm about to test this change, opening the PR early for discussion or help

thanks
