### PR TITLE
Prevent setting IDs when importing with on_duplicate_key_ignore

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -50,7 +50,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
     sql += super(table_name, options)
 
-    unless options[:no_returning] || options[:primary_key].blank?
+    unless options[:primary_key].blank? || options[:no_returning]
       primary_key = Array(options[:primary_key])
       sql << " RETURNING \"#{primary_key.join('", "')}\""
     end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -220,7 +220,9 @@ class ActiveRecord::Base
     #    records that contain duplicate keys. For Postgres 9.5+ it adds
     #    ON CONFLICT DO NOTHING, for MySQL it uses INSERT IGNORE, and for
     #    SQLite it uses INSERT OR IGNORE. Cannot be enabled on a
-    #    recursive import.
+    #    recursive import. For database adapters that normally support
+    #    setting primary keys on imported objects, this option prevents
+    #    that from occurring.
     # * +on_duplicate_key_update+ - an Array or Hash, tells import to
     #    use MySQL's ON DUPLICATE KEY UPDATE or Postgres 9.5+ ON CONFLICT
     #    DO UPDATE ability. See On Duplicate Key Update below.
@@ -519,7 +521,9 @@ class ActiveRecord::Base
 
       # if we have ids, then set the id on the models and mark the models as clean.
       if models && support_setting_primary_key_of_imported_objects?
-        set_attributes_and_mark_clean(models, return_obj, timestamps)
+        if options[:recursive] || !(options[:ignore] || options[:on_duplicate_key_ignore])
+          set_attributes_and_mark_clean(models, return_obj, timestamps)
+        end
 
         # if there are auto-save associations on the models we imported that are new, import them as well
         import_associations(models, options.dup) if options[:recursive]

--- a/test/support/shared_examples/on_duplicate_key_ignore.rb
+++ b/test/support/shared_examples/on_duplicate_key_ignore.rb
@@ -8,7 +8,9 @@ def should_support_on_duplicate_key_ignore
       it "should skip duplicates and continue import" do
         topics << Topic.new(title: "Book 2", author_name: "Jane Doe")
         assert_difference "Topic.count", +1 do
-          Topic.import topics, on_duplicate_key_ignore: true, validate: false
+          result = Topic.import topics, on_duplicate_key_ignore: true, validate: false
+          assert_not_equal topics.first.id, result.ids.first
+          assert_nil topics.last.id
         end
       end
 
@@ -31,7 +33,9 @@ def should_support_on_duplicate_key_ignore
       it "should skip duplicates and continue import" do
         topics << Topic.new(title: "Book 2", author_name: "Jane Doe")
         assert_difference "Topic.count", +1 do
-          Topic.import topics, ignore: true, validate: false
+          result = Topic.import topics, ignore: true, validate: false
+          assert_not_equal topics.first.id, result.ids.first
+          assert_nil topics.last.id
         end
       end
     end


### PR DESCRIPTION
When using :on_duplicate_key_ignore, Postgres only returns IDs for inserted records. This means that there is no way to know which models the returned IDs belong to so they cannot be set.

This resolves #411.