### PR TITLE
Mark clean after assigning attributes

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -657,14 +657,6 @@ class ActiveRecord::Base
     def set_attributes_and_mark_clean(models, import_result, timestamps)
       return if models.nil?
       models -= import_result.failed_instances
-      models.each do |model|
-        if model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
-          model.clear_changes_information
-        else # Rails 3.2
-          model.instance_variable_get(:@changed_attributes).clear
-        end
-        model.instance_variable_set(:@new_record, false)
-      end
 
       # if ids were returned for all models we know all were updated
       if models.size == import_result.ids.size
@@ -676,6 +668,15 @@ class ActiveRecord::Base
             model.send(attr + "=", value)
           end
         end
+      end
+
+      models.each do |model|
+        if model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
+          model.clear_changes_information
+        else # Rails 3.2
+          model.instance_variable_get(:@changed_attributes).clear
+        end
+        model.instance_variable_set(:@new_record, false)
       end
     end
 

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -24,6 +24,30 @@ def should_support_postgresql_import_functionality
       end
     end
 
+    context "setting attributes and marking clean" do
+      let(:topic) { Build(:topics) }
+
+      setup { Topic.import([topic]) }
+
+      it "assigns ids" do
+        assert topic.id.present?
+      end
+
+      it "marks models as clean" do
+        assert !topic.changed?
+      end
+
+      it "marks models as persisted" do
+        assert !topic.new_record?
+        assert topic.persisted?
+      end
+
+      it "assigns timestamps" do
+        assert topic.created_at.present?
+        assert topic.updated_at.present?
+      end
+    end
+
     describe "with query cache enabled" do
       setup do
         unless ActiveRecord::Base.connection.query_cache_enabled


### PR DESCRIPTION
This looks like it was a regression at some point.

Ids and timestamps must be assigned to models prior to marking the models as clean.