### PR TITLE
Crediting copied work

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,7 @@ Zach Dennis (zach.dennis@gmail.com)
 * Henry Work
 * James Herdman
 * Marcus Crafter
+* Sai (@saizai)
 * Thibaud Guillaume-Gentil
 * Mark Van Holstyn
 * Victor Costan


### PR DESCRIPTION
This work: https://github.com/zdennis/activerecord-import/blob/master/lib/activerecord-import/import.rb#L732
introduced at: https://github.com/zdennis/activerecord-import/pull/71/commits/0e5a577648d9a5e886accfc830b6bab073d3314e#diff-70d0c2152cc72037bcf5c177f03eb9f8L310

was originally mine: https://github.com/zdennis/activerecord-import/pull/45

… and is uncredited.