### PR TITLE
Raise error when value set byte size exceeds max allowed

### DIFF
--- a/test/value_sets_bytes_parser_test.rb
+++ b/test/value_sets_bytes_parser_test.rb
@@ -8,6 +8,15 @@ describe ActiveRecord::Import::ValueSetsBytesParser do
     let(:base_sql) { "INSERT INTO atable (a,b,c)" }
     let(:values) { ["(1,2,3)", "(2,3,4)", "(3,4,5)"] }
 
+    context "when the max allowed bytes is 30 and the base SQL is 26 bytes" do
+      it "should raise ActiveRecord::Import::ValueSetTooLargeError" do
+        error = assert_raises ActiveRecord::Import::ValueSetTooLargeError do
+          parser.parse values, reserved_bytes: base_sql.size, max_bytes: 30
+        end
+        assert_match(/33 bytes exceeds the max allowed for an insert \[30\]/, error.message)
+      end
+    end
+
     context "when the max allowed bytes is 33 and the base SQL is 26 bytes" do
       it "should return 3 value sets when given 3 value sets of 7 bytes a piece" do
         value_sets = parser.parse values, reserved_bytes: base_sql.size, max_bytes: 33


### PR DESCRIPTION
It is possible that an insert with a single value set could exceed the max allowed byte size. For MySQL that would be the value for the `max_allowed_packet setting`. This raises a more helpful error when that is the case. See #437.