### PR TITLE
Fix bypassing uniqueness validators

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -38,7 +38,7 @@ module ActiveRecord::Import #:nodoc:
         model.errors.clear
 
         validate_callbacks = model._validate_callbacks.dup
-        validate_callbacks.each do |callback|
+        model._validate_callbacks.each do |callback|
           validate_callbacks.delete(callback) if callback.raw_filter.is_a? ActiveRecord::Validations::UniquenessValidator
         end
 

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -121,12 +121,12 @@ describe "#import" do
   end
 
   context "with :validation option" do
-    let(:columns) { %w(title author_name) }
-    let(:valid_values) { [["LDAP", "Jerry Carter"], ["Rails Recipes", "Chad Fowler"]] }
-    let(:valid_values_with_context) { [[1111, "Jerry Carter"], [2222, "Chad Fowler"]] }
-    let(:invalid_values) { [["The RSpec Book", ""], ["Agile+UX", ""]] }
-    let(:valid_models) { valid_values.map { |title, author_name| Topic.new(title: title, author_name: author_name) } }
-    let(:invalid_models) { invalid_values.map { |title, author_name| Topic.new(title: title, author_name: author_name) } }
+    let(:columns) { %w(title author_name content) }
+    let(:valid_values) { [["LDAP", "Jerry Carter", "Putting Directories to Work."], ["Rails Recipes", "Chad Fowler", "A trusted collection of solutions."]] }
+    let(:valid_values_with_context) { [[1111, "Jerry Carter", "1111"], [2222, "Chad Fowler", "2222"]] }
+    let(:invalid_values) { [["The RSpec Book", "", "Get the most out of BDD in Ruby."], ["Agile+UX", "", "All about Agile in UX."]] }
+    let(:valid_models) { valid_values.map { |title, author_name, content| Topic.new(title: title, author_name: author_name, content: content) } }
+    let(:invalid_models) { invalid_values.map { |title, author_name, content| Topic.new(title: title, author_name: author_name, content: content) } }
 
     context "with validation checks turned off" do
       it "should import valid data" do

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -2,6 +2,7 @@ class Topic < ActiveRecord::Base
   validates_presence_of :author_name
   validates :title, numericality: { only_integer: true }, on: :context_test
   validates :title, uniqueness: true
+  validates :content, uniqueness: true
 
   validate -> { errors.add(:title, :validate_failed) if title == 'validate_failed' }
   before_validation -> { errors.add(:title, :invalid) if title == 'invalid' }

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
   factory :topic do
     sequence(:title) { |n| "Title #{n}" }
     sequence(:author_name) { |n| "Author #{n}" }
+    sequence(:content) { |n| "Content #{n}" }
   end
 
   factory :widget do

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -64,8 +64,8 @@ def should_support_mysql_import_functionality
       let(:columns) { %w(id author_name title) }
 
       setup do
-        topics << Topic.create!(title: "LDAP", author_name: "Big Bird")
-        topics << Topic.create!(title: "Rails Recipes", author_name: "Elmo")
+        topics << Topic.create!(title: "LDAP", author_name: "Big Bird", content: "Putting Directories to Work.")
+        topics << Topic.create!(title: "Rails Recipes", author_name: "Elmo", content: "A trusted collection of solutions.")
       end
 
       it "synchronizes passed in ActiveRecord model instances with the data just imported" do


### PR DESCRIPTION
When `Validator` is iterating over a callback chain and skips unique validations, it shifts the index whenever it deletes such item from the collection. If there are several successive uniqueness validators, it omits the one following the deleted one in the chain. That prevents from inserting data in such model when running with `:validate` option.

Do not mutate the target chain inside the enumerator and iterate over a copy instead.

Relates to https://github.com/zdennis/activerecord-import/pull/301.
Follow-up for https://github.com/zdennis/activerecord-import/pull/410.