### PR TITLE
Reset model instance on validate

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -570,8 +570,8 @@ class ActiveRecord::Base
 
         # keep track of the instance and the position it is currently at. if this fails
         # validation we'll use the index to remove it from the array_of_attributes
-        model = new
         arr.each_with_index do |hsh, i|
+          model = new
           hsh.each_pair { |k, v| model[k] = v }
           next if validator.valid_model? model
           raise(ActiveRecord::RecordInvalid, model) if options[:raise_error]

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -124,7 +124,7 @@ describe "#import" do
     let(:columns) { %w(title author_name content) }
     let(:valid_values) { [["LDAP", "Jerry Carter", "Putting Directories to Work."], ["Rails Recipes", "Chad Fowler", "A trusted collection of solutions."]] }
     let(:valid_values_with_context) { [[1111, "Jerry Carter", "1111"], [2222, "Chad Fowler", "2222"]] }
-    let(:invalid_values) { [["The RSpec Book", "", "Get the most out of BDD in Ruby."], ["Agile+UX", "", "All about Agile in UX."]] }
+    let(:invalid_values) { [["The RSpec Book", "David Chelimsky", "..."], ["Agile+UX", "", "All about Agile in UX."]] }
     let(:valid_models) { valid_values.map { |title, author_name, content| Topic.new(title: title, author_name: author_name, content: content) } }
     let(:invalid_models) { invalid_values.map { |title, author_name, content| Topic.new(title: title, author_name: author_name, content: content) } }
 

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -3,6 +3,7 @@ class Topic < ActiveRecord::Base
   validates :title, numericality: { only_integer: true }, on: :context_test
   validates :title, uniqueness: true
   validates :content, uniqueness: true
+  validates :word_count, numericality: { greater_than: 0 }, if: :content?
 
   validate -> { errors.add(:title, :validate_failed) if title == 'validate_failed' }
   before_validation -> { errors.add(:title, :invalid) if title == 'invalid' }
@@ -11,4 +12,10 @@ class Topic < ActiveRecord::Base
   belongs_to :parent, class_name: "Topic"
 
   composed_of :description, mapping: [%w(title title), %w(author_name author_name)], allow_nil: true, class_name: "TopicDescription"
+
+  private
+
+  def word_count
+    @word_count ||= content.to_s.scan(/\w+/).count
+  end
 end


### PR DESCRIPTION
When loading an array of hashes, the importer uses the same model instance whenever performs validations for each item. However, if there is a validator defined for a memoized attribute, it might provide false positives for valid values followed by invalid ones.

Instantiate a new object before validating a model to avoid such gotchas.