### PR TITLE
Use .unscoped to handle default scopes

### DIFF
--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -31,7 +31,7 @@ module ActiveRecord # :nodoc:
 
       klass = instances.first.class
 
-      fresh_instances = klass.where(conditions).order(order)
+      fresh_instances = klass.unscoped.where(conditions).order(order)
       instances.each do |instance|
         matched_instance = fresh_instances.detect do |fresh_instance|
           keys.all? { |key| fresh_instance.send(key) == instance.send(key) }


### PR DESCRIPTION
#454 