### PR TITLE
Allow SQL subqueries to be passed as values

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -783,6 +783,8 @@ class ActiveRecord::Base
           # be sure to query sequence_name *last*, only if cheaper tests fail, because it's costly
           if val.nil? && column.name == primary_key && !sequence_name.blank?
             connection_memo.next_value_for_sequence(sequence_name)
+          elsif val.respond_to?(:to_sql)
+            "(#{val.to_sql})"
           elsif column
             if respond_to?(:type_caster)                                         # Rails 5.0 and higher
               type = type_for_attribute(column.name)

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -760,5 +760,19 @@ describe "#import" do
         end
       end
     end
+
+    context "with objects that respond to .to_sql as values" do
+      let(:columns) { %w(title author_name) }
+      let(:valid_values) { [["LDAP", Book.select("'Jerry Carter'").limit(1)], ["Rails Recipes", Book.select("'Chad Fowler'").limit(1)]] }
+
+      it "should import data" do
+        assert_difference "Topic.count", +2 do
+          Topic.import! columns, valid_values
+          topics = Topic.all
+          assert_equal "Jerry Carter", topics.first.author_name
+          assert_equal "Chad Fowler", topics.last.author_name
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Objects that respond to `.to_sql` (`ActiveRecord::Relation`) can be passed as values when importing
arrays or hashes. See #467.