### PR TITLE
Load import support for currently active db adapter

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -1,19 +1,5 @@
 # rubocop:disable Style/FileName
 
 ActiveSupport.on_load(:active_record) do
-  class ActiveRecord::Base
-    class << self
-      def establish_connection_with_activerecord_import(*args)
-        conn = establish_connection_without_activerecord_import(*args)
-        if !ActiveRecord.const_defined?(:Import) || !ActiveRecord::Import.respond_to?(:load_from_connection_pool)
-          require "activerecord-import/base"
-        end
-
-        ActiveRecord::Import.load_from_connection_pool connection_pool
-        conn
-      end
-      alias establish_connection_without_activerecord_import establish_connection
-      alias establish_connection establish_connection_with_activerecord_import
-    end
-  end
+  require "activerecord-import/base"
 end

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -18,12 +18,9 @@ module ActiveRecord::Import
 
   # Loads the import functionality for a specific database adapter
   def self.require_adapter(adapter)
-    require File.join(ADAPTER_PATH, "/abstract_adapter")
-    begin
-      require File.join(ADAPTER_PATH, "/#{base_adapter(adapter)}_adapter")
-    rescue LoadError
-      # fallback
-    end
+    require File.join(ADAPTER_PATH, "/#{base_adapter(adapter)}_adapter")
+  rescue LoadError
+    # fallback
   end
 
   # Loads the import functionality for the passed in ActiveRecord connection

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -151,6 +151,15 @@ end
 
 class ActiveRecord::Base
   class << self
+    def establish_connection_with_activerecord_import(*args)
+      conn = establish_connection_without_activerecord_import(*args)
+      ActiveRecord::Import.load_from_connection_pool connection_pool
+      conn
+    end
+
+    alias establish_connection_without_activerecord_import establish_connection
+    alias establish_connection establish_connection_with_activerecord_import
+
     # Returns true if the current database connection adapter
     # supports import functionality, otherwise returns false.
     def supports_import?(*args)


### PR DESCRIPTION
Fixes issue loading import support when activerecord-import is not autoloaded by Bundler and ActiveRecord has already established a connection to the database.