### PR TITLE
Fix validation logic for recursive import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -592,7 +592,6 @@ class ActiveRecord::Base
         if models
           import_with_validations( column_names, array_of_attributes, options ) do |validator, failed|
             models.each_with_index do |model, i|
-              model = model.dup if options[:recursive]
               next if validator.valid_model? model
               raise(ActiveRecord::RecordInvalid, model) if options[:raise_error]
               array_of_attributes[i] = nil
@@ -812,6 +811,7 @@ class ActiveRecord::Base
     # of class => objects to import.
     def find_associated_objects_for_import(associated_objects_by_class, model)
       associated_objects_by_class[model.class.name] ||= {}
+      return associated_objects_by_class unless model.id
 
       association_reflections =
         model.class.reflect_on_all_associations(:has_one) +

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -90,6 +90,19 @@ def should_support_recursive_import
       end
     end
 
+    # Models are only valid if all associations are valid
+    it "only imports models with valid associations" do
+      assert_difference "Topic.count", 2 do
+        assert_difference "Book.count", 4 do
+          assert_difference "Chapter.count", 12 do
+            assert_difference "EndNote.count", 16 do
+              Topic.import new_topics_with_invalid_chapter, recursive: true
+            end
+          end
+        end
+      end
+    end
+
     it "skips validation of the associations if requested" do
       assert_difference "Chapter.count", +num_chapters do
         Topic.import new_topics_with_invalid_chapter, validate: false, recursive: true
@@ -132,20 +145,12 @@ def should_support_recursive_import
       end
     end
 
-    # These models dont validate associated.  So we expect that books and topics get inserted, but not chapters
-    # Putting a transaction around everything wouldn't work, so if you want your chapters to prevent topics from
-    # being created, you would need to have validates_associated in your models and insert with validation
     describe "all_or_none" do
-      [Book, Topic, EndNote].each do |type|
+      [Book, Chapter, Topic, EndNote].each do |type|
         it "creates #{type}" do
-          assert_difference "#{type}.count", send("num_#{type.to_s.downcase}s") do
+          assert_difference "#{type}.count", 0 do
             Topic.import new_topics_with_invalid_chapter, all_or_none: true, recursive: true
           end
-        end
-      end
-      it "doesn't create chapters" do
-        assert_difference "Chapter.count", 0 do
-          Topic.import new_topics_with_invalid_chapter, all_or_none: true, recursive: true
         end
       end
     end


### PR DESCRIPTION
This should resolve #488, but results in a subtle change when validating recursive imports. Only models with valid associations will be imported. Previously parent associations were imported regardless.