### PR TITLE
 Enabled to update lock_version of model

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -45,7 +45,7 @@ module ActiveRecord::Import::AbstractAdapter
       post_sql_statements = []
 
       if supports_on_duplicate_key_update? && options[:on_duplicate_key_update]
-        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:locking_column], options[:on_duplicate_key_update], options[:primary_key] )
+        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update], options[:primary_key], options[:locking_column] )
       elsif options[:on_duplicate_key_update]
         logger.warn "Ignoring on_duplicate_key_update because it is not supported by the database."
       end

--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -45,7 +45,7 @@ module ActiveRecord::Import::AbstractAdapter
       post_sql_statements = []
 
       if supports_on_duplicate_key_update? && options[:on_duplicate_key_update]
-        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update], options[:primary_key] )
+        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:locking_column], options[:on_duplicate_key_update], options[:primary_key] )
       elsif options[:on_duplicate_key_update]
         logger.warn "Ignoring on_duplicate_key_update because it is not supported by the database."
       end

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord::Import::MysqlAdapter
   end
 
   def model(table_name)
-    table_name.delete('`').singularize.camelize.constantize
+    ActiveRecord::Base.descendants.find { |t| "`#{t.table_name}`" == table_name }
   end
 
   def locking_column?(model)

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -84,9 +84,10 @@ module ActiveRecord::Import::MysqlAdapter
 
   # Returns a generated ON DUPLICATE KEY UPDATE statement given the passed
   # in +args+.
-  def sql_for_on_duplicate_key_update( table_name, locking_column, *args ) # :nodoc:
+  def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
     sql = ' ON DUPLICATE KEY UPDATE '
     arg = args.first
+    locking_column = args.last
     if arg.is_a?( Array )
       sql << sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arg )
     elsif arg.is_a?( Hash )

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -118,8 +118,8 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
   # Returns a generated ON CONFLICT DO UPDATE statement given the passed
   # in +args+.
-  def sql_for_on_duplicate_key_update( table_name, locking_column, *args ) # :nodoc:
-    arg, primary_key = args
+  def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
+    arg, primary_key, locking_column = args
     arg = { columns: arg } if arg.is_a?( Array ) || arg.is_a?( String )
     return unless arg.is_a?( Hash )
 

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -212,7 +212,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
   end
 
   def model(table_name)
-    table_name.delete('\"').singularize.camelize.constantize
+    ActiveRecord::Base.descendants.find { |t| "\"#{t.table_name}\"" == table_name }
   end
 
   def locking_column?(model)

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -118,7 +118,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
   # Returns a generated ON CONFLICT DO UPDATE statement given the passed
   # in +args+.
-  def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
+  def sql_for_on_duplicate_key_update( table_name, locking_column, *args ) # :nodoc:
     arg, primary_key = args
     arg = { columns: arg } if arg.is_a?( Array ) || arg.is_a?( String )
     return unless arg.is_a?( Hash )
@@ -139,9 +139,9 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
     sql << "#{conflict_target}DO UPDATE SET "
     if columns.is_a?( Array )
-      sql << sql_for_on_duplicate_key_update_as_array( table_name, columns )
+      sql << sql_for_on_duplicate_key_update_as_array( table_name, locking_column, columns )
     elsif columns.is_a?( Hash )
-      sql << sql_for_on_duplicate_key_update_as_hash( table_name, columns )
+      sql << sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, columns )
     elsif columns.is_a?( String )
       sql << columns
     else
@@ -153,22 +153,22 @@ module ActiveRecord::Import::PostgreSQLAdapter
     sql
   end
 
-  def sql_for_on_duplicate_key_update_as_array( table_name, arr ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arr ) # :nodoc:
     results = arr.map do |column|
       qc = quote_column_name( column )
       "#{qc}=EXCLUDED.#{qc}"
     end
-    increment_locking_column!(results, table_name)
+    increment_locking_column!(results, locking_column)
     results.join( ',' )
   end
 
-  def sql_for_on_duplicate_key_update_as_hash( table_name, hsh ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, hsh ) # :nodoc:
     results = hsh.map do |column1, column2|
       qc1 = quote_column_name( column1 )
       qc2 = quote_column_name( column2 )
       "#{qc1}=EXCLUDED.#{qc2}"
     end
-    increment_locking_column!(results, table_name)
+    increment_locking_column!(results, locking_column)
     results.join( ',' )
   end
 
@@ -203,19 +203,9 @@ module ActiveRecord::Import::PostgreSQLAdapter
     true
   end
 
-  def increment_locking_column!(results, table_name)
-    model = model(table_name)
-    locking_column = model.locking_column
-    if locking_column?(model)
+  def increment_locking_column!(results, locking_column)
+    if locking_column.present?
       results << "\"#{locking_column}\"=EXCLUDED.\"#{locking_column}\"+1"
     end
-  end
-
-  def model(table_name)
-    ActiveRecord::Base.descendants.find { |t| "\"#{t.table_name}\"" == table_name }
-  end
-
-  def locking_column?(model)
-    model.attribute_names.include?(model.locking_column)
   end
 end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -475,6 +475,7 @@ class ActiveRecord::Base
       options.merge!( args.pop ) if args.last.is_a? Hash
       # making sure that current model's primary key is used
       options[:primary_key] = primary_key
+      options[:locking_column] = locking_column if attribute_names.include?(locking_column)
 
       # Don't modify incoming arguments
       on_duplicate_key_update = options[:on_duplicate_key_update]

--- a/test/models/account.rb
+++ b/test/models/account.rb
@@ -1,0 +1,3 @@
+class Account < ActiveRecord::Base
+  self.locking_column = :lock
+end

--- a/test/models/bike_maker.rb
+++ b/test/models/bike_maker.rb
@@ -1,0 +1,7 @@
+module Bike
+  def self.table_name_prefix
+    'bike_'
+  end
+  class Maker < ActiveRecord::Base
+  end
+end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,0 +1,1 @@
+class User < ActiveRecord::Base; end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -159,6 +159,11 @@ ActiveRecord::Schema.define do
     t.string :Features
   end
 
+  create_table :users, force: :cascade do |t|
+    t.string :name, null: false
+    t.integer :lock_version, null: false, default: 0
+  end
+
   add_index :cars, :Name, unique: true
 
   unless ENV["SKIP_COMPOSITE_PK"]

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -164,6 +164,11 @@ ActiveRecord::Schema.define do
     t.integer :lock_version, null: false, default: 0
   end
 
+  create_table :accounts, force: :cascade do |t|
+    t.string :name, null: false
+    t.integer :lock, null: false, default: 0
+  end
+
   add_index :cars, :Name, unique: true
 
   unless ENV["SKIP_COMPOSITE_PK"]

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -169,6 +169,11 @@ ActiveRecord::Schema.define do
     t.integer :lock, null: false, default: 0
   end
 
+  create_table :bike_makers, force: :cascade do |t|
+    t.string :name, null: false
+    t.integer :lock_version, null: false, default: 0
+  end
+
   add_index :cars, :Name, unique: true
 
   unless ENV["SKIP_COMPOSITE_PK"]

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -142,6 +142,73 @@ def should_support_basic_on_duplicate_key_update
             assert_equal 1, user.lock
           end
         end
+
+        it 'update the lock_version of models separated by namespaces by model' do
+          makers = [
+            Bike::Maker.new(name: 'Yamaha'),
+            Bike::Maker.new(name: 'Honda')
+          ]
+          Bike::Maker.import(makers)
+          assert Bike::Maker.count == makers.length
+          Bike::Maker.all.each do |maker|
+            assert_equal 0, maker.lock_version
+          end
+          updated_makers = Bike::Maker.all.map do |maker|
+            maker.name += ' bikes'
+            maker
+          end
+          Bike::Maker.import(updated_makers, on_duplicate_key_update: [:name])
+          assert Bike::Maker.count == updated_makers.length
+          Bike::Maker.all.each_with_index do |maker, i|
+            assert_equal maker.name, makers[i].name + ' bikes'
+            assert_equal 1, maker.lock_version
+          end
+        end
+        it 'update the lock_version of models separated by namespaces by array' do
+          makers = [
+            Bike::Maker.new(name: 'Yamaha'),
+            Bike::Maker.new(name: 'Honda')
+          ]
+          Bike::Maker.import(makers)
+          assert Bike::Maker.count == makers.length
+          Bike::Maker.all.each do |maker|
+            assert_equal 0, maker.lock_version
+          end
+
+          columns = [:id, :name]
+          updated_values = Bike::Maker.all.map do |maker|
+            maker.name += ' bikes'
+            [maker.id, maker.name]
+          end
+          Bike::Maker.import(columns, updated_values, on_duplicate_key_update: [:name])
+          assert Bike::Maker.count == updated_values.length
+          Bike::Maker.all.each_with_index do |maker, i|
+            assert_equal maker.name, makers[i].name + ' bikes'
+            assert_equal 1, maker.lock_version
+          end
+        end
+
+        it 'update the lock_version of models separated by namespaces by hash' do
+          makers = [
+            Bike::Maker.new(name: 'Yamaha'),
+            Bike::Maker.new(name: 'Honda')
+          ]
+          Bike::Maker.import(makers)
+          assert Bike::Maker.count == makers.length
+          Bike::Maker.all.each do |maker|
+            assert_equal 0, maker.lock_version
+          end
+          updated_values = Bike::Maker.all.map do |maker|
+            maker.name += ' bikes'
+            { id: maker.id, name: maker.name }
+          end
+          Bike::Maker.import(updated_values, on_duplicate_key_update: [:name])
+          assert Bike::Maker.count == updated_values.length
+          Bike::Maker.all.each_with_index do |maker, i|
+            assert_equal maker.name, makers[i].name + ' bikes'
+            assert_equal 1, maker.lock_version
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Hi!
Thanks for making ActiveRecord-import!!
This is great gem!

# Purpose
I wanted to solve this problem
> It would be useful to automatically be able to increment the lock_version on duplicate key update.
#472 

# did
* [x] I tested mysql!.
* [x] I tested postgres.
* [x] Updatable divided by name spaces models. (like this `Bike::Maker`)
* [x] Upsert by Models
* [x] Upsert by Arrays
* [x] Upsert by Hashes

# Approach
* When checking if there is a lock_version column at the time of update processing, update it

Sorry for my poor English.
thank you for reading! (/･ω･)/