### PR TITLE
Fix import_without_validations_or_callbacks fails if array is empty

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -661,7 +661,7 @@ class ActiveRecord::Base
 
       array_of_attributes.compact!
 
-      result = if array_of_attributes.empty? || options[:all_or_none] && failed_instances.any?
+      result = if options[:all_or_none] && failed_instances.any?
         ActiveRecord::Import::Result.new([], 0, [], [])
       else
         import_without_validations_or_callbacks( column_names, array_of_attributes, options )
@@ -676,6 +676,8 @@ class ActiveRecord::Base
     # information on +column_names+, +array_of_attributes_ and
     # +options+.
     def import_without_validations_or_callbacks( column_names, array_of_attributes, options = {} )
+      return ActiveRecord::Import::Result.new([], 0, [], []) if array_of_attributes.empty?
+
       column_names = column_names.map(&:to_sym)
       scope_columns, scope_values = scope_attributes.to_a.transpose
 


### PR DESCRIPTION
In the latest version, `#import_without_validations_or_callbacks` raises "invalid slice size" exception because #each_slice is called with 0.

`#import_without_validations_or_callbacks` is a public API (Is my understanding correct?).
So it have to work even if `array_of_attributes` is empty.