### PR TITLE
Use the association primary key when importing

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -97,7 +97,7 @@ class ActiveRecord::Associations::CollectionAssociation
     symbolized_foreign_key = reflection.foreign_key.to_sym
     symbolized_column_names = model_klass.column_names.map(&:to_sym)
 
-    owner_primary_key = owner.class.primary_key
+    owner_primary_key = reflection.active_record_primary_key.to_sym
     owner_primary_key_value = owner.send(owner_primary_key)
 
     # assume array of model objects

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -596,6 +596,14 @@ describe "#import" do
           assert_equal [val1, val2], scope.map(&column).sort
         end
       end
+
+      it "works with a non-standard association primary key" do
+        user = User.create(id: 1, name: 'Solomon')
+        user.user_tokens.import [:id, :token], [[5, '12345abcdef67890']]
+
+        token = UserToken.find(5)
+        assert_equal 'Solomon', token.user_name
+      end
     end
   end
 

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,1 +1,3 @@
-class User < ActiveRecord::Base; end
+class User < ActiveRecord::Base
+  has_many :user_tokens, primary_key: :name, foreign_key: :user_name
+end

--- a/test/models/user_token.rb
+++ b/test/models/user_token.rb
@@ -1,0 +1,3 @@
+class UserToken < ActiveRecord::Base
+  belongs_to :user, primary_key: :name, foreign_key: :user_name
+end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -164,6 +164,11 @@ ActiveRecord::Schema.define do
     t.integer :lock_version, null: false, default: 0
   end
 
+  create_table :user_tokens, force: :cascade do |t|
+    t.string :user_name, null: false
+    t.string :token, null: false
+  end
+
   create_table :accounts, force: :cascade do |t|
     t.string :name, null: false
     t.integer :lock, null: false, default: 0


### PR DESCRIPTION
When importing into an association, it was using the owner class table primary key (usually `id`) rather than the `:primary_key` option specified on the association.