### PR TITLE
Add Makara Postgis adapter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ ADAPTERS = %w(
   postgresql
   postgresql_makara
   postgis
+  makara_postgis
   sqlite3
   spatialite
   seamless_database_pool

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -11,6 +11,7 @@ module ActiveRecord::Import
     when 'mysql2spatial' then 'mysql2'
     when 'spatialite' then 'sqlite3'
     when 'postgresql_makara' then 'postgresql'
+    when 'makara_postgis' then 'postgresql'
     when 'postgis' then 'postgresql'
     else adapter
     end

--- a/test/adapters/makara_postgis.rb
+++ b/test/adapters/makara_postgis.rb
@@ -1,0 +1,1 @@
+ENV["ARE_DB"] = "postgis"

--- a/test/makara_postgis/import_test.rb
+++ b/test/makara_postgis/import_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+require File.expand_path(File.dirname(__FILE__) + '/../support/postgresql/import_examples')
+
+should_support_postgresql_import_functionality
+
+if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+  should_support_postgresql_upsert_functionality
+end


### PR DESCRIPTION
As discussed in #526 there isn't support for the Makara Postgis adapter, so I figured I should change that.

This branch does fail the same tests as the existing postgis and postgresql adapters with the error `duplicate key value violates unique constraint "uk_code" DETAIL:  Key (code)=(abc) already exists.`