### PR TITLE
Add missing require for `ActiveSupport.on_load`

### DIFF
--- a/lib/activerecord-import.rb
+++ b/lib/activerecord-import.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Style/FileName
+require "active_support/lazy_load_hooks"
 
 ActiveSupport.on_load(:active_record) do
   require "activerecord-import/base"


### PR DESCRIPTION
## Steps to reproduce the problem

```
$ cat Gemfile
source "https://rubygems.org"
gem "activerecord-import"
```

```
$ bundle console
```

### Expected

The console is started.

```
irb(main):001:0>
```

### Actual

An error occurs.

```
There was an error while trying to load the gem 'activerecord-import'.
Gem Load Error is: uninitialized constant ActiveSupport
Backtrace for gem load error is:
/Users/onaka/.bundle/ruby/2.6.0/gems/activerecord-import-0.24.0/lib/activerecord-import.rb:3:in `<top (required)>'
/Users/onaka/.gem/ruby/2.6.0/gems/bundler-1.16.2/lib/bundler/runtime.rb:81:in `require'
...
```
