### PR TITLE
Handle deeply frozen on_duplicate_key_update options hashes

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -634,11 +634,13 @@ class ActiveRecord::Base
       if on_duplicate_key_update
         updatable_columns = symbolized_column_names.reject { |c| symbolized_primary_key.include? c }
         options[:on_duplicate_key_update] = if on_duplicate_key_update.is_a?(Hash)
-          on_duplicate_key_update.each do |k, v|
-            if k == :columns && v == :all
-              on_duplicate_key_update[k] = updatable_columns
+          on_duplicate_key_update.each_with_object({}) do |(k, v), duped_options|
+            duped_options[k] = if k == :columns && v == :all
+              updatable_columns
             elsif v.duplicable?
-              on_duplicate_key_update[k] = v.dup
+              v.dup
+            else
+              v
             end
           end
         elsif on_duplicate_key_update == :all

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -336,7 +336,7 @@ def should_support_postgresql_upsert_functionality
           it "should not modify the passed in :on_duplicate_key_update columns array" do
             assert_nothing_raised do
               columns = %w(title author_name).freeze
-              Topic.import columns, [%w(foo, bar)], on_duplicate_key_update: { columns: columns }
+              Topic.import columns, [%w(foo, bar)], { on_duplicate_key_update: { columns: columns }.freeze }.freeze
             end
           end
 


### PR DESCRIPTION
This fixes a regression introduced by #451 that prevents the `import` method from working with deeply frozen `on_duplicate_key_update` option hashes.