### PR TITLE
Use `Factory Bot` instead of `Factory Girl`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ platforms :jruby do
 end
 
 # Support libs
-gem "factory_girl", "~> 4.2.0"
+gem "factory_bot"
 gem "timecop"
 gem "chronic"
 gem "mocha", "~> 1.3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ ADAPTERS.each do |adapter|
   namespace :test do
     desc "Runs #{adapter} database tests."
     Rake::TestTask.new(adapter) do |t|
-      # FactoryGirl has an issue with warnings, so turn off, so noisy
+      # FactoryBot has an issue with warnings, so turn off, so noisy
       # t.warning = true
       t.test_files = FileList["test/adapters/#{adapter}.rb", "test/*_test.rb", "test/active_record/*_test.rb", "test/#{adapter}/**/*_test.rb"]
     end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -567,7 +567,7 @@ describe "#import" do
 
   context "importing through an association scope" do
     { has_many: :chapters, polymorphic: :discounts }.each do |association_type, association|
-      book   = FactoryGirl.create :book
+      book   = FactoryBot.create :book
       scope  = book.public_send association
       klass  = { chapters: Chapter, discounts: Discount }[association]
       column = { chapters: :title,  discounts: :amount  }[association]
@@ -609,7 +609,7 @@ describe "#import" do
 
   context "importing model with polymorphic belongs_to" do
     it "works without error" do
-      book     = FactoryGirl.create :book
+      book     = FactoryBot.create :book
       discount = Discount.new(discountable: book)
 
       Discount.import([discount])

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:book_title) { |n| "Book #{n}" }
   sequence(:chapter_title) { |n| "Chapter #{n}" }
   sequence(:end_note) { |n| "Endnote #{n}" }
@@ -27,7 +27,7 @@ FactoryGirl.define do
 
     trait :with_rule do
       after(:build) do |question|
-        question.build_rule(FactoryGirl.attributes_for(:rule))
+        question.build_rule(FactoryBot.attributes_for(:rule))
       end
     end
   end
@@ -40,13 +40,13 @@ FactoryGirl.define do
   factory :topic_with_book, parent: :topic do
     after(:build) do |topic|
       2.times do
-        book = topic.books.build(title: FactoryGirl.generate(:book_title), author_name: 'Stephen King')
+        book = topic.books.build(title: FactoryBot.generate(:book_title), author_name: 'Stephen King')
         3.times do
-          book.chapters.build(title: FactoryGirl.generate(:chapter_title))
+          book.chapters.build(title: FactoryBot.generate(:chapter_title))
         end
 
         4.times do
-          book.end_notes.build(note: FactoryGirl.generate(:end_note))
+          book.end_notes.build(note: FactoryBot.generate(:end_note))
         end
       end
     end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
   factory :invalid_topic, class: "Topic" do
     sequence(:title) { |n| "Title #{n}" }
-    author_name nil
+    author_name { nil }
   end
 
   factory :topic do
@@ -53,8 +53,8 @@ FactoryBot.define do
   end
 
   factory :book do
-    title 'Tortilla Flat'
-    author_name 'John Steinbeck'
+    title { 'Tortilla Flat' }
+    author_name { 'John Steinbeck' }
   end
 
   factory :car do

--- a/test/support/generate.rb
+++ b/test/support/generate.rb
@@ -2,28 +2,28 @@ class ActiveSupport::TestCase
   def Build(*args) # rubocop:disable Style/MethodName
     n = args.shift if args.first.is_a?(Numeric)
     factory = args.shift
-    factory_girl_args = args.shift || {}
+    factory_bot_args = args.shift || {}
 
     if n
       [].tap do |collection|
-        n.times.each { collection << FactoryGirl.build(factory.to_s.singularize.to_sym, factory_girl_args) }
+        n.times.each { collection << FactoryBot.build(factory.to_s.singularize.to_sym, factory_bot_args) }
       end
     else
-      FactoryGirl.build(factory.to_s.singularize.to_sym, factory_girl_args)
+      FactoryBot.build(factory.to_s.singularize.to_sym, factory_bot_args)
     end
   end
 
   def Generate(*args) # rubocop:disable Style/MethodName
     n = args.shift if args.first.is_a?(Numeric)
     factory = args.shift
-    factory_girl_args = args.shift || {}
+    factory_bot_args = args.shift || {}
 
     if n
       [].tap do |collection|
-        n.times.each { collection << FactoryGirl.create(factory.to_s.singularize.to_sym, factory_girl_args) }
+        n.times.each { collection << FactoryBot.create(factory.to_s.singularize.to_sym, factory_bot_args) }
       end
     else
-      FactoryGirl.create(factory.to_s.singularize.to_sym, factory_girl_args)
+      FactoryBot.create(factory.to_s.singularize.to_sym, factory_bot_args)
     end
   end
 end

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -11,7 +11,7 @@ def should_support_recursive_import
     let(:num_chapters) { 18 }
     let(:num_endnotes) { 24 }
 
-    let(:new_question_with_rule) { FactoryGirl.build :question, :with_rule }
+    let(:new_question_with_rule) { FactoryBot.build :question, :with_rule }
 
     it 'imports top level' do
       assert_difference "Topic.count", +num_topics do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,7 +58,7 @@ ActiveSupport::Notifications.subscribe(/active_record.sql/) do |_, _, _, _, hsh|
   ActiveRecord::Base.logger.info hsh[:sql]
 end
 
-require "factory_girl"
+require "factory_bot"
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |file| require file }
 
 # Load base/generic schema


### PR DESCRIPTION
Factory Girl has been renamed to Factory Bot.

cf. https://github.com/thoughtbot/factory_bot/blob/master/NAME.md

And this PR suppresses the following Factory Bot's deprecation warning.

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot
5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

title { "Tortilla Flat" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```