### PR TITLE
Allow .import to work with ProxySQL

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -56,7 +56,7 @@ module ActiveRecord::Import::MysqlAdapter
   # in a single packet
   def max_allowed_packet # :nodoc:
     @max_allowed_packet ||= begin
-      result = execute( "SHOW VARIABLES like 'max_allowed_packet';" )
+      result = execute( "SHOW VARIABLES like 'max_allowed_packet'" )
       # original Mysql gem responds to #fetch_row while Mysql2 responds to #first
       val = result.respond_to?(:fetch_row) ? result.fetch_row[1] : result.first[1]
       val.to_i


### PR DESCRIPTION
Remove extraneous ';' from command to query mysql max_allowed_packet

There was an un-necessary semicolon at the end of the command to query
the MySQL servers max_allowed_packet global variable.
 If ProxySQL was in between activerecord-import and the database then
 this semicolon would cause "Mysql2::Error: Commands out of sync" errors.

These errors occur if multiple queries are performed without reading the
responses of all of them. The semicolon through ProxySQL caused an extra
query and these errors.

Remove the semicolon here as it is unnecessary, triggers a problem in
this particular case, and may cause issues in other cases also.