### PR TITLE
Add option to include uniqueness validators

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -42,7 +42,7 @@ module ActiveRecord::Import #:nodoc:
 
         model._validate_callbacks.each do |callback|
           filter = callback.raw_filter
-          if filter.is_a?(ActiveRecord::Validations::UniquenessValidator) ||
+          if (!@options[:validate_uniqueness] && filter.is_a?(ActiveRecord::Validations::UniquenessValidator)) ||
              (defined?(ActiveRecord::Validations::PresenceValidator) && filter.is_a?(ActiveRecord::Validations::PresenceValidator) && associations.include?(filter.attributes.first))
             validate_callbacks.delete(callback)
           end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -210,9 +210,9 @@ describe "#import" do
       end
 
       it "should ignore uniqueness validators" do
-        Topic.import columns, valid_values, validate: true
+        Topic.import columns, valid_values
         assert_difference "Topic.count", +2 do
-          Topic.import columns, valid_values, validate: true
+          Topic.import columns, valid_values
         end
       end
 
@@ -291,6 +291,15 @@ describe "#import" do
       it "should call validation methods" do
         assert_no_difference "Topic.count" do
           Topic.import columns, [["validate_failed", "Jerry Carter"]], validate: true
+        end
+      end
+    end
+
+    context "with uniqueness validators included" do
+      it "should not import duplicate records" do
+        Topic.import columns, valid_values
+        assert_no_difference "Topic.count" do
+          Topic.import columns, valid_values, validate_uniqueness: true
         end
       end
     end


### PR DESCRIPTION
Adds a "secret" option to include uniqueness validators. This is not a recommended approach because there are several pitfalls to attempting uniqueness validation, but in order to provide legacy support for projects that depend on this feature, this has been added back into the library.