### PR TITLE
Fix validating presence of belongs_to associations

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -303,6 +303,20 @@ describe "#import" do
         end
       end
     end
+
+    context "when validatoring presence of belongs_to association" do
+      it "should not import records without foreign key" do
+        assert_no_difference "UserToken.count" do
+          UserToken.import [:token], [['12345abcdef67890']]
+        end
+      end
+
+      it "should import records with foreign key" do
+        assert_difference "UserToken.count", +1 do
+          UserToken.import [:user_name, :token], [%w("Bob", "12345abcdef67890")]
+        end
+      end
+    end
   end
 
   context "without :validation option" do

--- a/test/models/user_token.rb
+++ b/test/models/user_token.rb
@@ -1,3 +1,4 @@
 class UserToken < ActiveRecord::Base
   belongs_to :user, primary_key: :name, foreign_key: :user_name
+  validates :user, presence: true
 end


### PR DESCRIPTION
Parent associations will not be checked to see if they exist, but instead the foreign key field will be checked for a value. Fixes #571.