### PR TITLE
Move ActiveRecord::Dirty changes to previous_changes after import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -862,7 +862,9 @@ class ActiveRecord::Base
       end
 
       models.each do |model|
-        if model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
+        if model.respond_to?(:changes_applied) # Rails 4.1.8 and higher
+          model.changes_applied
+        elsif model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
           model.clear_changes_information
         else # Rails 3.2
           model.instance_variable_get(:@changed_attributes).clear

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -863,6 +863,7 @@ class ActiveRecord::Base
 
       models.each do |model|
         if model.respond_to?(:changes_applied) # Rails 4.1.8 and higher
+          model.changes_internally_applied if model.respond_to?(:changes_internally_applied) # legacy behavior for Rails 5.1
           model.changes_applied
         elsif model.respond_to?(:clear_changes_information) # Rails 4.0 and higher
           model.clear_changes_information

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -37,6 +37,12 @@ def should_support_postgresql_import_functionality
         assert !topic.changed?
       end
 
+      if ENV['AR_VERSION'].to_f > 4.1
+        it "moves the dirty changes to previous_changes" do
+          assert topic.previous_changes.present?
+        end
+      end
+
       it "marks models as persisted" do
         assert !topic.new_record?
         assert topic.persisted?


### PR DESCRIPTION
There is a legal `ActiveRecord::Dirty.changes_applied` finalization method starting from `v4.1.8`.

It will clean the Dirty `changes` as usually, and will populate the `previous_changes` in additional - can be useful for further processing.

Actually, I need that right now :)