### PR TITLE
A better error message for a corner case that resulted to hard-to-decipher errors.

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -976,6 +976,8 @@ class ActiveRecord::Base
               val = column.type_cast(val) unless column.type.to_sym == :binary
               connection_memo.quote(val, column)
             end
+          else
+            raise ArgumentError, "Too much values (#{arr.length} compared to columns #{columns.length})"
           end
         end
         "(#{my_values.join(',')})"

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -977,7 +977,7 @@ class ActiveRecord::Base
               connection_memo.quote(val, column)
             end
           else
-            raise ArgumentError, "Too much values (#{arr.length} compared to columns #{columns.length})"
+            raise ArgumentError, "Number of values (#{arr.length}) exceeds number of columns (#{columns.length})"
           end
         end
         "(#{my_values.join(',')})"

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -19,7 +19,7 @@ describe "#import" do
 
   it "warns you that you're passing more data than you ought to" do
     error = assert_raise(ArgumentError) { Topic.import %w(title author_name), [['Author #1', 'Book #1', 0]] }
-    assert_equal error.message, "Too much values (8 compared to columns 7)"
+    assert_equal error.message, "Number of values (8) exceeds number of columns (7)"
   end
 
   it "should not produce an error when importing empty arrays" do

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -17,6 +17,11 @@ describe "#import" do
     assert_equal error.message, "Last argument should be a two dimensional array '[[]]'. First element in array was a String"
   end
 
+  it "warns you that you're passing more data than you ought to" do
+    error = assert_raise(ArgumentError) { Topic.import %w(title author_name), [['Author #1', 'Book #1', 0]] }
+    assert_equal error.message, "Too much values (8 compared to columns 7)"
+  end
+
   it "should not produce an error when importing empty arrays" do
     assert_nothing_raised do
       Topic.import []


### PR DESCRIPTION
Currently, when the user uses the arrays-of-arrays import mechanism, if there is more values than columns, it just produces broken SQL query such as
```
INSERT INTO table (col1, col2) VALUES ("val", "val2",)
```
Note the final comma. After it, there is a `nil` value that doesn't get printed. The reason the `nil` gets there is because if `column = columns[j]` in `values_sql_for_columns_and_attributes` overflows, `column` is going to be `nil` and not match any of the conditions, producing, again a `nil`.

A malformed SQL query is something definitely not desirable. I don't know about the general ideology behind this library, (whether you want to be loud about errors or ignore the case where there is too much data but you still manage to get on) but at least throwing an error message is certainly better than it currently is, and doesn't come here with an additional cost.