### PR TITLE
Fix ActiveRecord::Base respond_to? check

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -528,7 +528,7 @@ class ActiveRecord::Base
         import_helper(*args)
       end
     end
-    alias import bulk_import unless respond_to? :import
+    alias import bulk_import unless ActiveRecord::Base.respond_to? :import
 
     # Imports a collection of values if all values are valid. Import fails at the
     # first encountered validation error and raises ActiveRecord::RecordInvalid
@@ -540,7 +540,7 @@ class ActiveRecord::Base
 
       bulk_import(*args, options)
     end
-    alias import! bulk_import! unless respond_to? :import!
+    alias import! bulk_import! unless ActiveRecord::Base.respond_to? :import!
 
     def import_helper( *args )
       options = { validate: true, timestamps: true }


### PR DESCRIPTION
## What's in this PR?
This PR fixes two instances of the "only setup alias if it isn't already defined" pattern.

The reason these two instances need a tweak is because they are within a `class << self` which involves the singleton (eigenclass) class and can be non-trivial to work with.

Inside of a `class << self` block, `self` actually refers to an instance, not a class, and it's actually unique - so these two `respond_to?` checks will actually never return true, because the unique `class << self` blocks don't define an `import` method.

## Example

Paste these examples into a rails console to see the output - the first one demonstrates the problem, the second one demonstrates the solution.

```
class ActiveRecord::Base
  class << self
    def bla
    end
  end
end

class ActiveRecord::Base
  class << self
    puts respond_to? :bla # returns false (doh)
  end
end
```

```
class ActiveRecord::Base
  class << self
    def bla
    end
  end
end

class ActiveRecord::Base
  class << self
    puts ActiveRecord::Base.respond_to? :bla # returns true (yay)
  end
end
```