### PR TITLE
Fix import of saved json[b] fields for postgres

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -577,10 +577,10 @@ class ActiveRecord::Base
         default_values = column_defaults
         stored_attrs = respond_to?(:stored_attributes) ? stored_attributes : {}
         serialized_attrs = if defined?(ActiveRecord::Type::Serialized)
-          attrs = column_names.select { |c|
+          attrs = column_names.select do |c|
             attribute_type = type_for_attribute(c.to_s)
-            attribute_type.class == ActiveRecord::Type::Serialized || %i[json jsonb].include?(attribute_type.type)
-          }
+            attribute_type.class == ActiveRecord::Type::Serialized || %i(json jsonb).include?(attribute_type.type)
+          end
           Hash[attrs.map { |a| [a, nil] }]
         else
           serialized_attributes

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -577,7 +577,10 @@ class ActiveRecord::Base
         default_values = column_defaults
         stored_attrs = respond_to?(:stored_attributes) ? stored_attributes : {}
         serialized_attrs = if defined?(ActiveRecord::Type::Serialized)
-          attrs = column_names.select { |c| type_for_attribute(c.to_s).class == ActiveRecord::Type::Serialized }
+          attrs = column_names.select { |c|
+            attribute_type = type_for_attribute(c.to_s)
+            attribute_type.class == ActiveRecord::Type::Serialized || %i[json jsonb].include?(attribute_type.type)
+          }
           Hash[attrs.map { |a| [a, nil] }]
         else
           serialized_attributes

--- a/test/schema/postgresql_schema.rb
+++ b/test/schema/postgresql_schema.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define do
     t.text :preferences
 
     if t.respond_to?(:json)
+      t.json :pure_json_data
       t.json :data
     else
       t.text :data
@@ -20,6 +21,7 @@ ActiveRecord::Schema.define do
     end
 
     if t.respond_to?(:jsonb)
+      t.jsonb :pure_jsonb_data
       t.jsonb :settings
       t.jsonb :json_data, null: false, default: {}
     else

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -234,6 +234,19 @@ def should_support_postgresql_import_functionality
         assert_equal({}, Vendor.first.json_data)
       end
     end
+
+    %w[json jsonb].each do |json_type|
+      describe "with pure #{json_type} fields" do
+        let(:data) { {a: :b} }
+        let(:json_field_name) { "pure_#{json_type}_data" }
+        it "imports the values from saved records" do
+          vendor = Vendor.create!(name: 'Vendor 1', json_field_name => data)
+
+          Vendor.import [vendor], on_duplicate_key_update: [json_field_name]
+          assert_equal(data.as_json, vendor.reload[json_field_name])
+        end
+      end
+    end
   end
 
   describe "with binary field" do

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -235,9 +235,9 @@ def should_support_postgresql_import_functionality
       end
     end
 
-    %w[json jsonb].each do |json_type|
+    %w(json jsonb).each do |json_type|
       describe "with pure #{json_type} fields" do
-        let(:data) { {a: :b} }
+        let(:data) { { a: :b } }
         let(:json_field_name) { "pure_#{json_type}_data" }
         it "imports the values from saved records" do
           vendor = Vendor.create!(name: 'Vendor 1', json_field_name => data)


### PR DESCRIPTION
Well, `activerecord-import` silently corrupted a tons of the data on my server 💣
Fortunately, that was a staging one, and it's possible to revert this time 🍀 😃 

How that happened:
1) I have a pure `jsonb` postgres field - without default value (don't ask me why 😞), without `serialize` nor  `store_accessor` definition on model layer.
2) I use `ActiveRecord.import` with `on_duplicate_key_update` turned on.
3) everything is fine when the new value comes there for `jsonb` field. But...
4) if `jsonb` field was not changed - `activerecord-import` will take it from `AR#read_attribute_before_type_cast`. As a result in DB it will replace the original `jsonb` object with that object serialized to JSON **twice**. Postgres will silently accepts that, because such **string** is valid JSON string...
5) Each time when import was called - the things becomes to be worse and worse for particular record 🔥, starting from normal `{"a": "b"}` JSON object, till `"\"\\\"{\\\\\\\"a\\\\\\\": \\\\\\\"b\\\\\\\"}\\\"\""` and further! 🚀

The fix is similar to https://github.com/zdennis/activerecord-import/commit/2a6158d68ff128c5c88a47d92b8b9051aff8e145. It fixes pure `json` case as well.