### PR TITLE
Don't pass returning on recursive import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -904,8 +904,9 @@ class ActiveRecord::Base
       associated_objects_by_class = {}
       models.each { |model| find_associated_objects_for_import(associated_objects_by_class, model) }
 
-      # :on_duplicate_key_update not supported for associations
+      # :on_duplicate_key_update and :returning not supported for associations
       options.delete(:on_duplicate_key_update)
+      options.delete(:returning)
 
       associated_objects_by_class.each_value do |associations|
         associations.each_value do |associated_records|

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -183,5 +183,20 @@ def should_support_recursive_import
         end
       end
     end
+
+    # If returning option is provided, it is only applied to top level models so that SQL with invalid
+    # columns, keys, etc isn't generated for child associations when doing recursive import
+    describe "returning" do
+      let(:new_topics) { Build(1, :topic_with_book) }
+
+      it "imports objects with associations" do
+        assert_difference "Topic.count", +1 do
+          Topic.import new_topics, recursive: true, returning: [:content], validate: false
+          new_topics.each do |topic|
+            assert_not_nil topic.id
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Same reason `on_duplicate_key_update` is not passed to associations on
recursive import currently, must be applied to `returning` option, which
is otherwise unusable with recursive import.