### PR TITLE
add cockroachdb to adapter detection

### DIFF
--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -13,6 +13,7 @@ module ActiveRecord::Import
     when 'postgresql_makara' then 'postgresql'
     when 'makara_postgis' then 'postgresql'
     when 'postgis' then 'postgresql'
+    when 'cockroachdb' then 'postgresql'
     else adapter
     end
   end


### PR DESCRIPTION
Required for cockroachdb since it works with the postgresql adapter.

See https://www.cockroachlabs.com/docs/stable/build-a-ruby-app-with-cockroachdb-activerecord.html