### PR TITLE
Clear aggregation cache if model uses aggregations

### DIFF
--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -39,8 +39,8 @@ module ActiveRecord # :nodoc:
 
         next unless matched_instance
 
-        instance.send :clear_aggregation_cache
         instance.send :clear_association_cache
+        instance.send :clear_aggregation_cache if instance.respond_to?(:clear_aggregation_cache, true)
         instance.instance_variable_set :@attributes, matched_instance.instance_variable_get(:@attributes)
 
         if instance.respond_to?(:clear_changes_information)


### PR DESCRIPTION
Fixes #622. Aggregations are now loaded lazily. See: https://github.com/rails/rails/commit/657060b5f8c14fc6249fc19231f703a7c749d84e#diff-391caa9b9464021e932ebf657fa9b13c