### PR TITLE
Fix sqlite3's version to 1.3.6 series

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ version = ENV['AR_VERSION'].to_f
 
 mysql2_version = '0.3.0'
 mysql2_version = '0.4.0' if version >= 4.2
-sqlite3_version = '1.3.0'
-sqlite3_version = '1.4.0' if version >= 5.1
 
 group :development, :test do
   gem 'rubocop', '~> 0.40.0'
@@ -18,7 +16,7 @@ end
 platforms :ruby do
   gem "mysql2",                 "~> #{mysql2_version}"
   gem "pg",                     "~> 0.9"
-  gem "sqlite3",                "~> #{sqlite3_version}"
+  gem "sqlite3",                "~> 1.3.6"
   gem "seamless_database_pool", "~> 1.0.20"
 end
 


### PR DESCRIPTION
# Description
When install activerecord-import with Rails 5.1, it depends to sqlite3 `1.4`.
But Rails does not yet support the sqlite3 `1.4` system.
Therefore, installation of splite3 has failed.
![image](https://user-images.githubusercontent.com/12161701/61990198-c0df4d00-b076-11e9-88eb-68ca3a6badf1.png)
https://travis-ci.org/zdennis/activerecord-import/jobs/552287397

The solution is to install the sqlite3 version `1.3.6`.
rails/rails#35153

# Motivation and Context
I was worried that the build was an error and fixed it.
https://travis-ci.org/zdennis/activerecord-import

# How Has This Been Tested?
I tested in local environment as follows and confirmed that it works.

local environment
OS : macOS 10.14.6
Ruby : 2.5.1p57
Rails : 5.2.3


Thanks for making your project Open Source! Any feedback is greatly appreciated.