### PR TITLE
Fix NoMethodError when using PostgreSQL ENUM types

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -964,7 +964,7 @@ class ActiveRecord::Base
                 val = serialized_attributes[column.name].dump(val)
               end
               # Fixes #443 to support binary (i.e. bytea) columns on PG
-              val = column.type_cast(val) unless column.type&.to_sym == :binary
+              val = column.type_cast(val) unless column.type && column.type.to_sym == :binary
               connection_memo.quote(val, column)
             end
           else

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -964,7 +964,7 @@ class ActiveRecord::Base
                 val = serialized_attributes[column.name].dump(val)
               end
               # Fixes #443 to support binary (i.e. bytea) columns on PG
-              val = column.type_cast(val) unless column.type.to_sym == :binary
+              val = column.type_cast(val) unless column.type&.to_sym == :binary
               connection_memo.quote(val, column)
             end
           else

--- a/test/schema/postgresql_schema.rb
+++ b/test/schema/postgresql_schema.rb
@@ -3,6 +3,15 @@ ActiveRecord::Schema.define do
   execute('CREATE extension IF NOT EXISTS "pgcrypto";')
   execute('CREATE extension IF NOT EXISTS "uuid-ossp";')
 
+  # create ENUM if it does not exist yet
+  begin
+    execute('CREATE TYPE vendor_type AS ENUM (\'wholesaler\', \'retailer\');')
+  rescue ActiveRecord::StatementInvalid => e
+    raise unless e.cause.is_a? PG::DuplicateObject
+    execute('ALTER TYPE vendor_type ADD VALUE IF NOT EXISTS \'wholesaler\';')
+    execute('ALTER TYPE vendor_type ADD VALUE IF NOT EXISTS \'retailer\';')
+  end
+
   create_table :vendors, id: :uuid, force: :cascade do |t|
     t.string :name, null: true
     t.text :preferences
@@ -28,6 +37,8 @@ ActiveRecord::Schema.define do
       t.text :settings
       t.text :json_data
     end
+
+    t.column :vendor_type, :vendor_type
 
     t.datetime :created_at
     t.datetime :updated_at

--- a/test/schema/postgresql_schema.rb
+++ b/test/schema/postgresql_schema.rb
@@ -7,6 +7,8 @@ ActiveRecord::Schema.define do
   begin
     execute('CREATE TYPE vendor_type AS ENUM (\'wholesaler\', \'retailer\');')
   rescue ActiveRecord::StatementInvalid => e
+    # since PostgreSQL does not support IF NOT EXISTS when creating a TYPE,
+    # rescue the error and check the error class
     raise unless e.cause.is_a? PG::DuplicateObject
     execute('ALTER TYPE vendor_type ADD VALUE IF NOT EXISTS \'wholesaler\';')
     execute('ALTER TYPE vendor_type ADD VALUE IF NOT EXISTS \'retailer\';')

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -260,6 +260,17 @@ def should_support_postgresql_import_functionality
     end
   end
 
+  describe "with enum field" do
+    let(:vendor_type) { "retailer" }
+    it "imports the correct values for enum fields" do
+      vendor = Vendor.new(name: 'Vendor 1', vendor_type: vendor_type)
+      assert_difference "Vendor.count", +1 do
+        Vendor.import [vendor]
+      end
+      assert_equal(vendor_type, Vendor.first.vendor_type)
+    end
+  end
+
   describe "with binary field" do
     let(:binary_value) { "\xE0'c\xB2\xB0\xB3Bh\\\xC2M\xB1m\\I\xC4r".force_encoding('ASCII-8BIT') }
     it "imports the correct values for binary fields" do


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/zdennis/activerecord-import/issues/650.

By checking if the `.type` is `nil`, there is no longer a risk of calling `.to_sym` on a `nil` value.

I have added a `ENUM` field to the PostgreSQL schema for the tests. Because PostgreSQL does not support using `IF NOT EXISTS` on a `CREATE TYPE` statement, I had to implement the same logic by rescuing the correct exception type and then calling `ALTER TYPE` in the `rescue` block.