### PR TITLE
Fix #655: optimistic lock in Postgres

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -158,7 +158,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       qc = quote_column_name( column )
       "#{qc}=EXCLUDED.#{qc}"
     end
-    increment_locking_column!(results, locking_column)
+    increment_locking_column!(table_name, results, locking_column)
     results.join( ',' )
   end
 
@@ -168,7 +168,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       qc2 = quote_column_name( column2 )
       "#{qc1}=EXCLUDED.#{qc2}"
     end
-    increment_locking_column!(results, locking_column)
+    increment_locking_column!(table_name, results, locking_column)
     results.join( ',' )
   end
 
@@ -203,9 +203,9 @@ module ActiveRecord::Import::PostgreSQLAdapter
     true
   end
 
-  def increment_locking_column!(results, locking_column)
+  def increment_locking_column!(table_name, results, locking_column)
     if locking_column.present?
-      results << "\"#{locking_column}\"=EXCLUDED.\"#{locking_column}\"+1"
+      results << "\"#{locking_column}\"=#{table_name}.\"#{locking_column}\"+1"
     end
   end
 

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -73,6 +73,16 @@ def should_support_basic_on_duplicate_key_update
             assert_equal user.name, users[i].name + ' Rothschild'
             assert_equal 1, user.lock_version
           end
+          updated_values2 = User.all.map do |user|
+            user.name += ' jr.'
+            { id: user.id, name: user.name }
+          end
+          User.import(updated_values2, on_duplicate_key_update: [:name])
+          assert User.count == updated_values2.length
+          User.all.each_with_index do |user, i|
+            assert_equal user.name, users[i].name + ' Rothschild jr.'
+            assert_equal 2, user.lock_version
+          end
         end
 
         it 'upsert optimistic lock columns other than lock_version by model' do


### PR DESCRIPTION
Fixes https://github.com/zdennis/activerecord-import/issues/655

For the record, the tricky case if `lock_version` is nullable and is null is handled neither by this gem, nor by AR (tested with v 4.2). 