### PR TITLE
Allow Filtering of repeated instances when doing an import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -965,7 +965,7 @@ class ActiveRecord::Base
           elsif column
             if respond_to?(:type_caster)                                         # Rails 5.0 and higher
               type = type_for_attribute(column.name)
-              val = type.type == :boolean ? type.cast(val) : type.serialize(val)
+              val = !type.respond_to?(:subtype) && type.type == :boolean ? type.cast(val) : type.serialize(val)
               connection_memo.quote(val)
             elsif column.respond_to?(:type_cast_from_user)                       # Rails 4.2
               connection_memo.quote(column.type_cast_from_user(val), column)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -992,9 +992,10 @@ class ActiveRecord::Base
       associated_objects_by_class = {}
       models.each { |model| find_associated_objects_for_import(associated_objects_by_class, model) }
 
-      # :on_duplicate_key_update and :returning not supported for associations
+      # :on_duplicate_key_update, :returning and :unique_records_by not supported for associations
       options.delete(:on_duplicate_key_update)
       options.delete(:returning)
+      options.delete(:unique_records_by)
 
       associated_objects_by_class.each_value do |associations|
         associations.each_value do |associated_records|

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -241,8 +241,9 @@ end
 
 module ActiveRecord::Import::Connection
   def establish_connection(args = nil)
-    super(args)
+    conn = super(args)
     ActiveRecord::Import.load_from_connection_pool connection_pool
+    conn
   end
 end
 

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -582,6 +582,17 @@ class ActiveRecord::Base
 
         array_of_attributes = []
 
+        if options.key?(:unique_records_by)
+          columns = options.fetch(:unique_records_by, :all)
+
+          # If :all is specified, let's use all available column names to filter records
+          # if not, let's use the specified array of symbols/strings and public send those
+          # to the active record object.
+          columns = column_names if columns == :all
+
+          models.uniq! { |model| columns.map { |c| model.public_send(c) } }
+        end
+
         models.each do |model|
           if supports_setting_primary_key_of_imported_objects?
             load_association_ids(model)
@@ -612,6 +623,17 @@ class ActiveRecord::Base
           array_of_hashes = args.first
           column_names = array_of_hashes.first.keys
           allow_extra_hash_keys = false
+        end
+
+        if options.key?(:unique_records_by)
+          columns = options.fetch(:unique_records_by, :all)
+
+          # If :all is specified, let's use all available column names to filter records
+          # if not, let's use the specified array of symbols/strings and public send those
+          # to the active record object.
+          columns = column_names if columns == :all
+
+          array_of_hashes.uniq! { |hash| columns.map { |c| hash[c] } }
         end
 
         array_of_attributes = array_of_hashes.map do |h|

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -5,6 +5,7 @@ def should_support_mysql_import_functionality
 
   should_support_basic_on_duplicate_key_update
   should_support_on_duplicate_key_ignore
+  should_support_import_unique_records
 
   describe "#import" do
     context "with :on_duplicate_key_update and validation checks turned off" do

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 def should_support_postgresql_import_functionality
   should_support_recursive_import
+  should_support_import_unique_records
 
   if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
     should_support_postgresql_upsert_functionality

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -39,8 +39,8 @@ def should_support_postgresql_import_functionality
       end
 
       it 'does not fail when trying to perform the import' do
-        assert_difference [->{ Topic.count }, ->{ Book.count }], 1 do
-          res = Topic.import topics, unique_records_by: :all, recursive: true
+        assert_difference [-> { Topic.count }, -> { Book.count }], 1 do
+          Topic.import topics, unique_records_by: :all, recursive: true
         end
       end
     end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -25,6 +25,26 @@ def should_support_postgresql_import_functionality
       end
     end
 
+    # We need to do this here, because the recursive option is only supported by postgres implementation.
+    context 'when specifying associations on the models' do
+      let(:topics) do
+        Array.new(5) do |n|
+          Topic.new(
+            author_name: 'John Doe',
+            books: [Book.new(title: "Book #{n}", author_name: 'John Doe')],
+            content: 'Content Doe',
+            title: 'Sir John'
+          )
+        end
+      end
+
+      it 'does not fail when trying to perform the import' do
+        assert_difference [->{ Topic.count }, ->{ Book.count }], 1 do
+          res = Topic.import topics, unique_records_by: :all, recursive: true
+        end
+      end
+    end
+
     context "setting attributes and marking clean" do
       let(:topic) { Build(:topics) }
 

--- a/test/support/shared_examples/import_unique_records.rb
+++ b/test/support/shared_examples/import_unique_records.rb
@@ -1,0 +1,57 @@
+def should_support_import_unique_records
+  describe '#import' do
+    extend ActiveSupport::TestCase::ImportAssertions
+
+    context 'with :unique_records_by' do
+      context 'when comparing with :all columns' do
+        let(:topics) do
+          10.times.map do |_n|
+            Topic.new(author_name: 'John Doe', title: 'Sir John', content: 'Content Doe')
+          end
+        end
+
+        it 'skips duplicated instances passed for import when comparing by all columns' do
+          assert_difference 'Topic.count', +1 do
+            Topic.import topics, unique_records_by: :all
+          end
+        end
+
+        it 'imports all different instances that do not have the same value in all columns' do
+          topics.last.title = 'Sir John last'
+
+          assert_difference 'Topic.count', +2 do
+            Topic.import topics, unique_records_by: :all
+          end
+        end
+      end
+
+      context 'when comparing with specific columns' do
+        let(:topics) do
+          5.times.map do |n|
+            Topic.new(author_name: 'John Doe', title: "Sir John #{n}", content: 'Content Doe')
+          end
+        end
+
+        it 'skips instances that share the same value in the specified columns' do
+          5.times do |n|
+            topics << Topic.new(author_name: 'John Doe', title: "Sir John #{n}")
+          end
+
+          assert_difference 'Topic.count', +5 do
+            Topic.import topics, unique_records_by: %i[title]
+          end
+        end
+      end
+
+      it 'skips duplicated hashes passed for import' do
+        topic_hashes = 5.times.map do |_n|
+          { author_name: 'John Doe', title: 'Sir John', content: 'Content Doe' }
+        end
+
+        assert_difference 'Topic.count', +1 do
+          Topic.import topic_hashes, unique_records_by: :all
+        end
+      end
+    end
+  end
+end

--- a/test/support/shared_examples/import_unique_records.rb
+++ b/test/support/shared_examples/import_unique_records.rb
@@ -5,7 +5,7 @@ def should_support_import_unique_records
     context 'with :unique_records_by' do
       context 'when comparing with :all columns' do
         let(:topics) do
-          10.times.map do |_n|
+          Array.new(5) do
             Topic.new(author_name: 'John Doe', title: 'Sir John', content: 'Content Doe')
           end
         end
@@ -27,7 +27,7 @@ def should_support_import_unique_records
 
       context 'when comparing with specific columns' do
         let(:topics) do
-          5.times.map do |n|
+          Array.new(5) do |n|
             Topic.new(author_name: 'John Doe', title: "Sir John #{n}", content: 'Content Doe')
           end
         end
@@ -38,13 +38,13 @@ def should_support_import_unique_records
           end
 
           assert_difference 'Topic.count', +5 do
-            Topic.import topics, unique_records_by: %i[title]
+            Topic.import topics, unique_records_by: %i(title)
           end
         end
       end
 
       it 'skips duplicated hashes passed for import' do
-        topic_hashes = 5.times.map do |_n|
+        topic_hashes = Array.new(5) do
           { author_name: 'John Doe', title: 'Sir John', content: 'Content Doe' }
         end
 

--- a/test/support/sqlite3/import_examples.rb
+++ b/test/support/sqlite3/import_examples.rb
@@ -4,6 +4,8 @@ def should_support_sqlite3_import_functionality
     should_support_sqlite_upsert_functionality
   end
 
+  should_support_import_unique_records
+
   describe "#supports_imports?" do
     it "should support import" do
       assert ActiveRecord::Base.supports_import?


### PR DESCRIPTION
Sometimes, we might have repeated instances in the array passed to the import and those might cause a fail while inserting, because the same value is being inserted more than once when it shouldn't be possible. This is pretty useful for upsert operations.

This PR adds a `unique_records_by` option, which if present, depending on the value, it will try to filter the passed elements for import. It also works for hashes.