### PR TITLE
Fix compatibility issue because of not returning ActiveRecord::Connection from #establish_connection

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -241,8 +241,9 @@ end
 
 module ActiveRecord::Import::Connection
   def establish_connection(args = nil)
-    super(args)
+    conn = super(args)
     ActiveRecord::Import.load_from_connection_pool connection_pool
+    conn
   end
 end
 


### PR DESCRIPTION
After updating activerecord-import to v1.0.4, our project has started failing.

The cause of this problem is `#establish_connection` returns TrueClass/FalseClass (changed by #648).

Some gem expect the method to return `ActiveRecord::ConnectionAdapters::ConnectionPool` which is returned by original #establish_connection.
(I found this problem by using `activerecord-sharding` gem with activerecord-import.)