### PR TITLE
Support PostgreSQL array

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -949,7 +949,7 @@ class ActiveRecord::Base
           elsif column
             if respond_to?(:type_caster)                                         # Rails 5.0 and higher
               type = type_for_attribute(column.name)
-              val = type.type == :boolean ? type.cast(val) : type.serialize(val)
+              val = !type.respond_to?(:subtype) && type.type == :boolean ? type.cast(val) : type.serialize(val)
               connection_memo.quote(val)
             elsif column.respond_to?(:type_cast_from_user)                       # Rails 4.2
               connection_memo.quote(column.type_cast_from_user(val), column)


### PR DESCRIPTION
* Problem: If the column type is boolean with array: true, it fails with `can't quote Array` error
    ```
    TypeError: can't quote Array
    /vendor/bundle/2.6.5/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/quoting.rb:186:in `_quote'
    /vendor/bundle/2.6.5/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/postgresql/quoting.rb:98:in `_quote'
    /vendor/bundle/2.6.5/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/quoting.rb:23:in `quote'
    /vendor/bundle/2.6.5/gems/activerecord-import-1.0.4/lib/activerecord-import/import.rb:953:in `block (2 levels) in values_sql_for_columns_and_attributes'
    ...
    ```
* Solution: Skip checking if it's boolean if it's a container of other types, such as ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Vector, or ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.