### PR TITLE
when having a custom `.to_sql` method, import fails due to syntax errors

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -961,7 +961,7 @@ class ActiveRecord::Base
           if val.nil? && Array(primary_key).first == column.name && !sequence_name.blank?
             connection_memo.next_value_for_sequence(sequence_name)
           elsif val.respond_to?(:to_sql)
-            "(#{val.to_sql})"
+            "('#{val.to_sql}')"
           elsif column
             if respond_to?(:type_caster)                                         # Rails 5.0 and higher
               type = type_for_attribute(column.name)


### PR DESCRIPTION
in my projects, `DateTime` responds to `.to_sql` for working with them in DB context... this causes `activerecord-import` to fail on datetime fields....