### PR TITLE
Skip load association ids when column changed

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -882,10 +882,12 @@ class ActiveRecord::Base
 
     # Sync belongs_to association ids with foreign key field
     def load_association_ids(model)
+      changed_columns = model.changed
       association_reflections = model.class.reflect_on_all_associations(:belongs_to)
       association_reflections.each do |association_reflection|
         column_name = association_reflection.foreign_key
         next if association_reflection.options[:polymorphic]
+        next if changed_columns.include?(column_name)
         association = model.association(association_reflection.name)
         association = association.target
         next if association.blank? || model.public_send(column_name).present?

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -138,6 +138,15 @@ def should_support_recursive_import
       books.each do |book|
         assert_equal book.topic_id, second_new_topic.id
       end
+
+      books.each { |book| book.topic_id = nil }
+      assert_no_difference "Book.count", books.size do
+        Book.import books, validate: false, on_duplicate_key_update: [:topic_id]
+      end
+
+      books.each do |book|
+        assert_equal book.topic_id, nil
+      end
     end
 
     unless ENV["SKIP_COMPOSITE_PK"]


### PR DESCRIPTION
We define association id even when we change this column, because of this it is impossible to set `nil`
Maybe we can skip such `load associations`, what do you think?