### PR TITLE
Update README to note early on that `import` might be named `bulk_import` for compatibility reasons

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,8 @@ The gem provides the following high-level features:
 
 #### Introduction
 
+This gem adds an `import` method (or `bulk_import`, for compatibility with gems like `elasticsearch-model`; see [Conflicts With Other Gems](#conflicts-with-other-gems) to ActiveRecord classes.
+
 Without `activerecord-import`, you'd write something like this:
 
 ```ruby

--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ The gem provides the following high-level features:
 
 #### Introduction
 
-This gem adds an `import` method (or `bulk_import`, for compatibility with gems like `elasticsearch-model`; see [Conflicts With Other Gems](#conflicts-with-other-gems) to ActiveRecord classes.
+This gem adds an `import` method (or `bulk_import`, for compatibility with gems like `elasticsearch-model`; see [Conflicts With Other Gems](#conflicts-with-other-gems)) to ActiveRecord classes.
 
 Without `activerecord-import`, you'd write something like this:
 


### PR DESCRIPTION
### Description
Adds a line in the introduction of the README that notes the `import` method might not be aliased as that, and would have to be called with `bulk_import` if other conflicting gems are present. Since the method is a such major and important part of this gem, I thought it would be best to quickly note this upfront since the debugging information encountered might be a bit mysterious. 