### PR TITLE
Add benchmarks/log/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pkg
 log/*.log
 test.db
 test/database.yml
+benchmarks/log/
 
 .ruby-*
 .bundle/


### PR DESCRIPTION
The PR adds `benchmarks/log/` to `.gitignore`.