### PR TITLE
use a more compatible mechanism for determining this session variable

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -56,7 +56,7 @@ module ActiveRecord::Import::MysqlAdapter
   # in a single packet
   def max_allowed_packet # :nodoc:
     @max_allowed_packet ||= begin
-      result = execute( "SHOW VARIABLES like 'max_allowed_packet'" )
+      result = execute( "SELECT @@max_allowed_packet" )
       # original Mysql gem responds to #fetch_row while Mysql2 responds to #first
       val = result.respond_to?(:fetch_row) ? result.fetch_row[1] : result.first[1]
       val.to_i


### PR DESCRIPTION
In an effort to try to make a more cross DB compatible way to fetch the `max_allowed_packet` variable on AWS RDS MySQL instances migrated to via AWS DMS.

See: https://github.com/zdennis/activerecord-import/issues/705