### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["zach.dennis@gmail.com"]
   gem.summary       = "Bulk insert extension for ActiveRecord"
   gem.description   = "A library for bulk inserting data using ActiveRecord."
-  gem.homepage      = "http://github.com/zdennis/activerecord-import"
+  gem.homepage      = "https://github.com/zdennis/activerecord-import"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/activerecord-import or some tools or APIs that use the gem's metadata.