### PR TITLE
Fetch value from correct field/col from result row

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -58,7 +58,7 @@ module ActiveRecord::Import::MysqlAdapter
     @max_allowed_packet ||= begin
       result = execute( "SELECT @@max_allowed_packet" )
       # original Mysql gem responds to #fetch_row while Mysql2 responds to #first
-      val = result.respond_to?(:fetch_row) ? result.fetch_row[1] : result.first[1]
+      val = result.respond_to?(:fetch_row) ? result.fetch_row[0] : result.first[0]
       val.to_i
     end
   end


### PR DESCRIPTION
@jkowens I sincerely apologize for this ... your sorta scooped up my PR faster than I was able to process it through our QA process for the application we are integrating this gem into... I think the result row has essentially only 1 column now given the new `SELECT @@` syntax... 

I would really like to backfill some spec/test code here, but I am having a really hard time finding the correct strategy for testing this code.

Site note: see also the rails implementation of `show_variable` https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/AbstractMysqlAdapter.html#method-i-show_variable (the @@ syntax is what they have been using since at least rails 4)