### PR TITLE
to prevent mass-assignment errors in strict mode

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -703,7 +703,8 @@ class ActiveRecord::Base
             # keep track of the instance and the position it is currently at. if this fails
             # validation we'll use the index to remove it from the array_of_attributes
             arr.each_with_index do |hsh, i|
-              model = new(hsh)
+              model = new
+              hsh.each_pair { |k, v| model[k] = v }
               next if validator.valid_model?(model)
               raise(ActiveRecord::RecordInvalid, model) if options[:raise_error]
               array_of_attributes[i] = nil

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -703,10 +703,13 @@ class ActiveRecord::Base
             # keep track of the instance and the position it is currently at. if this fails
             # validation we'll use the index to remove it from the array_of_attributes
             arr.each_with_index do |hsh, i|
-              model = new
-              hsh.each_pair { |k, v| model[k] = v }
+              model = new do |m|
+                hsh.each_pair { |k, v| m[k] = v }
+              end
+
               next if validator.valid_model?(model)
               raise(ActiveRecord::RecordInvalid, model) if options[:raise_error]
+
               array_of_attributes[i] = nil
               failure = model.dup
               failure.errors.send(:initialize_dup, model.errors)

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -703,6 +703,7 @@ class ActiveRecord::Base
             # keep track of the instance and the position it is currently at. if this fails
             # validation we'll use the index to remove it from the array_of_attributes
             arr.each_with_index do |hsh, i|
+              # utilize block initializer syntax to prevent failure when 'mass_assignment_sanitizer = :strict'
               model = new do |m|
                 hsh.each_pair { |k, v| m[k] = v }
               end


### PR DESCRIPTION
We run our application in `:strict` mass assignment error mode in our test suite, and make heavy use of the this gem ... I would like to propose switching back to the longer form of attribute assignment to prevent errors with some of our models.

If we could open a discussion on this PR it would be very helpful for us to understand why the change was made, and what options we have going forward.

It looks like the short-form of assignment was introduced here: https://github.com/zdennis/activerecord-import/compare/v1.0.5...v1.0.6#diff-70d0c2152cc72037bcf5c177f03eb9f8L700-L701