### PR TITLE
Only load connection pool for the one adapter that needs it, rather than on every connection

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -255,7 +255,7 @@ end
 
 class ActiveRecord::Base
   class << self
-    prepend ActiveRecord::Import::Connection
+    prepend ActiveRecord::Import::Connection if defined?(SeamlessDatabasePool)
 
     # Returns true if the current database connection adapter
     # supports import functionality, otherwise returns false.
@@ -522,6 +522,8 @@ class ActiveRecord::Base
     # * ids - the primary keys of the imported ids if the adapter supports it, otherwise an empty array.
     # * results - import results if the adapter supports it, otherwise an empty array.
     def bulk_import(*args)
+      ActiveRecord::Import.load_from_connection_pool connection_pool
+
       if args.first.is_a?( Array ) && args.first.first.is_a?(ActiveRecord::Base)
         options = {}
         options.merge!( args.pop ) if args.last.is_a?(Hash)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,6 +60,7 @@ end
 ActiveRecord::Base.default_timezone = :utc
 
 require "activerecord-import"
+ActiveRecord::Import.require_adapter(adapter)
 ActiveRecord::Base.establish_connection :test
 
 ActiveSupport::Notifications.subscribe(/active_record.sql/) do |_, _, _, _, hsh|


### PR DESCRIPTION
What do you think vis-a-vis #715? Any reason we couldn't do this connection pool load at the time of import rather than at load time for every AR model? 