### PR TITLE
Better query cache clearing strategy

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       else
         select_values( sql2insert, *args )
       end
-      query_cache.clear_query_cache if query_cache_enabled
+      clear_query_cache if query_cache_enabled
     end
 
     if options[:returning].blank?

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       else
         select_values( sql2insert, *args )
       end
-      query_cache.clear if query_cache_enabled
+      query_cache.clear_query_cache if query_cache_enabled
     end
 
     if options[:returning].blank?


### PR DESCRIPTION
This PR is an attempt to fix an issue we experienced when migrating our rails app from 6.0 to 6.1.

We recently tried to migrate our Rails app to the latest version (6.1). Our test suites being green we decided to upgrade our production environment. That's when we started to see a random error:

`can't add a new key into hash during iteration` in `lib/active_record/connection_adapters/abstract/query_cache.rb`

This issue occurs in the `cache_sql` method: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L115

Not all our rails app have this issue so it's definitively linked to a gem we are using. When searching in all our gems only one seems to manipulate the `@query_cache` object.

In your PG adapter, you use `query_cache.clear`. In the `QueryCache` class they have a different method which seems to be using a lock : https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L90

I wasn't able to reproduce the bug with a test (concurrency issues are pretty hard to emulate).

The other thing bugging me is that this caching behaviour has been there for ages, I clearly have no explanations about why it started failing with 6.1+ :(
