### PR TITLE
Add warning to ActiveRecord::Import::Result unsupported attribute by other than postgresql.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -382,6 +382,8 @@ Book.import books, validate_uniqueness: true
 
 The `import` method returns a `Result` object that responds to `failed_instances` and `num_inserts`. Additionally, for users of Postgres, there will be two arrays `ids` and `results` that can be accessed`.
 
+`ids` and `results` outputs warning when other than Postgres. If you don't want to output. Add with_warn option `result.ids(with_warn: false)`
+
 ```ruby
 articles = [
   Article.new(author_id: 1, title: 'First Article', content: 'This is the first article'),

--- a/lib/activerecord-import/import/result.rb
+++ b/lib/activerecord-import/import/result.rb
@@ -1,0 +1,37 @@
+module ActiveRecord::Import #:nodoc:
+  class Result
+    attr_accessor :failed_instances
+    attr_writer :num_inserts, :ids, :results
+    def initialize(failed_instances, num_inserts, ids, results)
+      @failed_instances = failed_instances
+      @num_inserts = num_inserts
+      @ids = ids
+      @results = results
+    end
+
+    def num_inserts(with_warn: true)
+      warn 'Info: ActiveRecord::Import::Result#num_inserts is not an increased record count. It is the number of inserts it took to import the data.' if with_warn
+      @num_inserts ||= num_inserts
+    end
+
+    def ids(with_warn: true)
+      warn_unsuppored_attribute(__method__) if adapter_name != :postgresql && with_warn
+      @ids ||= ids
+    end
+
+    def results(with_warn: true)
+      warn_unsuppored_attribute(__method__) if adapter_name != :postgresql && with_warn
+      @results ||= results
+    end
+
+    private
+
+    def adapter_name
+      @adapter_name ||= ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+    end
+
+    def warn_unsuppored_attribute(method_name)
+      warn "Warning: ActiveRecord::Import::Result unsupported attribute: ##{method_name}. adaputer: #{adapter_name}"
+    end
+  end
+end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -5,10 +5,10 @@ describe "#import" do
     # see ActiveRecord::ConnectionAdapters::AbstractAdapter test for more specifics
     assert_difference "Topic.count", +10 do
       result = Topic.import Build(3, :topics)
-      assert result.num_inserts > 0
+      assert result.num_inserts(with_warn: false) > 0
 
       result = Topic.import Build(7, :topics)
-      assert result.num_inserts > 0
+      assert result.num_inserts(with_warn: false) > 0
     end
   end
 
@@ -386,7 +386,7 @@ describe "#import" do
 
       it "should report the zero inserts" do
         results = Topic.import columns, mixed_values, all_or_none: true
-        assert_equal 0, results.num_inserts
+        assert_equal 0, results.num_inserts(with_warn: false)
       end
     end
   end
@@ -395,14 +395,14 @@ describe "#import" do
     it "should import with a single insert" do
       assert_difference "Topic.count", +10 do
         result = Topic.import Build(10, :topics), batch_size: 10
-        assert_equal 1, result.num_inserts if Topic.supports_import?
+        assert_equal 1, result.num_inserts(with_warn: false) if Topic.supports_import?
       end
     end
 
     it "should import with multiple inserts" do
       assert_difference "Topic.count", +10 do
         result = Topic.import Build(10, :topics), batch_size: 4
-        assert_equal 3, result.num_inserts if Topic.supports_import?
+        assert_equal 3, result.num_inserts(with_warn: false) if Topic.supports_import?
       end
     end
   end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -17,10 +17,10 @@ def should_support_postgresql_import_functionality
       # see ActiveRecord::ConnectionAdapters::AbstractAdapter test for more specifics
       assert_difference "Topic.count", +10 do
         result = Topic.import Build(3, :topics)
-        assert_equal 1, result.num_inserts
+        assert_equal 1, result.num_inserts(with_warn: false)
 
         result = Topic.import Build(7, :topics)
-        assert_equal 1, result.num_inserts
+        assert_equal 1, result.num_inserts(with_warn: false)
       end
     end
 

--- a/test/support/shared_examples/on_duplicate_key_ignore.rb
+++ b/test/support/shared_examples/on_duplicate_key_ignore.rb
@@ -9,7 +9,7 @@ def should_support_on_duplicate_key_ignore
         topics << Topic.new(title: "Book 2", author_name: "Jane Doe")
         assert_difference "Topic.count", +1 do
           result = Topic.import topics, on_duplicate_key_ignore: true, validate: false
-          assert_not_equal topics.first.id, result.ids.first
+          assert_not_equal topics.first.id, result.ids(with_warn: false).first
           assert_nil topics.last.id
         end
       end
@@ -34,7 +34,7 @@ def should_support_on_duplicate_key_ignore
         topics << Topic.new(title: "Book 2", author_name: "Jane Doe")
         assert_difference "Topic.count", +1 do
           result = Topic.import topics, ignore: true, validate: false
-          assert_not_equal topics.first.id, result.ids.first
+          assert_not_equal topics.first.id, result.ids(with_warn: false).first
           assert_nil topics.last.id
         end
       end

--- a/test/support/sqlite3/import_examples.rb
+++ b/test/support/sqlite3/import_examples.rb
@@ -14,11 +14,11 @@ def should_support_sqlite3_import_functionality
     it "imports with a single insert on SQLite 3.7.11 or higher" do
       assert_difference "Topic.count", +507 do
         result = Topic.import Build(7, :topics)
-        assert_equal 1, result.num_inserts, "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
+        assert_equal 1, result.num_inserts(with_warn: false), "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
         assert_equal 7, Topic.count, "Failed to insert all records. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
 
         result = Topic.import Build(500, :topics)
-        assert_equal 1, result.num_inserts, "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
+        assert_equal 1, result.num_inserts(with_warn: false), "Failed to issue a single INSERT statement. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
         assert_equal 507, Topic.count, "Failed to insert all records. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
       end
     end
@@ -26,7 +26,7 @@ def should_support_sqlite3_import_functionality
     it "imports with a two inserts on SQLite 3.7.11 or higher" do
       assert_difference "Topic.count", +501 do
         result = Topic.import Build(501, :topics)
-        assert_equal 2, result.num_inserts, "Failed to issue a two INSERT statements. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
+        assert_equal 2, result.num_inserts(with_warn: false), "Failed to issue a two INSERT statements. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
         assert_equal 501, Topic.count, "Failed to insert all records. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
       end
     end
@@ -34,7 +34,7 @@ def should_support_sqlite3_import_functionality
     it "imports with a five inserts on SQLite 3.7.11 or higher" do
       assert_difference "Topic.count", +2500 do
         result = Topic.import Build(2500, :topics)
-        assert_equal 5, result.num_inserts, "Failed to issue a two INSERT statements. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
+        assert_equal 5, result.num_inserts(with_warn: false), "Failed to issue a two INSERT statements. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
         assert_equal 2500, Topic.count, "Failed to insert all records. Make sure you have a supported version of SQLite3 (3.7.11 or higher) installed"
       end
     end
@@ -62,7 +62,7 @@ def should_support_sqlite_upsert_functionality
 
       it "should not update any records" do
         result = Topic.import columns, updated_values, on_duplicate_key_ignore: true, validate: false
-        assert_equal [], result.ids
+        assert_equal [], result.ids(with_warn: false)
       end
     end
 


### PR DESCRIPTION
ActiveRecord::Import::Result has some unsupported attributes by other than postgresql.
So I think this attribute must out warning if called by other than postgresql. 
issues: https://github.com/zdennis/activerecord-import/issues/723