### PR TITLE
Support monitoring batched bulk importing progress by supplying a proc 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -231,7 +231,7 @@ columns = [ :title ]
 Book.import columns, books, batch_size: 2
 ```
 
-If you are working with particularly large datasets being imported via batches, you might want a way to report back on progress. This is supported by passing a callable as the `batch_progress` option. e.g:
+If your import is particularly large or slow (possibly due to [callbacks](#callbacks)) whilst batch importing, you might want a way to report back on progress. This is supported by passing a callable as the `batch_progress` option. e.g:
 
 ```ruby
 my_proc = ->(rows_size, num_batches, current_batch_number, batch_duration_in_secs) {

--- a/README.markdown
+++ b/README.markdown
@@ -231,6 +231,18 @@ columns = [ :title ]
 Book.import columns, books, batch_size: 2
 ```
 
+If you are working with particularly large datasets being imported via batches, you might want a way to report back on progress. This is supported by passing a callable as the `batch_progress` option. e.g:
+
+```ruby
+my_proc = ->(rows_size, num_batches, current_batch_number, batch_duration_in_secs) {
+  # Using the arguments provided to the callable, you can
+  # send an email, post to a websocket,
+  # update slack, alert if import is taking too long, etc.
+}
+
+Book.import columns, books, batch_size: 2, batch_progress: my_proc
+```
+
 #### Recursive
 
 NOTE: This only works with PostgreSQL and ActiveRecord objects. This won't work with

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -405,6 +405,15 @@ describe "#import" do
         assert_equal 3, result.num_inserts if Topic.supports_import?
       end
     end
+
+    it "should accept and call an optional callable to run after each batch" do
+      lambda_called = 0
+
+      my_proc = ->(_row_count, _batches, _batch, _duration) { lambda_called += 1 }
+      Topic.import Build(10, :topics), batch_size: 4, batch_progress: my_proc
+
+      assert_equal 3, lambda_called
+    end
   end
 
   context "with :synchronize option" do


### PR DESCRIPTION
Hi there,

We have a pretty hairy problem whereby we are importing around 500k rows into a db from a spreadsheet uploaded by a user.

We have a progress bar on our app that displays the upload progress to the user, but the majority of the upload time is taken by the import (upwards of 95% of the total duration). To the user looking at the progress bar, it appears as if the upload has hung.

I've implemented a small feature into this super useful gem that allows us to send a proc as the value to a `batch_progress` option. If a callable is supplied, it will be fed these arguments:

* `rows_size` - the total amount of rows to be imported
* `num_batches` - the total amount of batches required
* `current_batch_number` - the current batch
* `batch_duration_in_secs` - how long this batch took in seconds.

This will allow us to send a small lambda into the import process that can report back to our progress meter, and give the user pretty fine grained feedback on how their upload is progressing.

Here's an example from the updated README:

```ruby
slack_client = A::Slack::Client::From::Somewhere.new
web_sock = A::Web::Socket::Adapter::From::Somewhere.new

my_proc = ->(rows_size, num_batches, current_batch_number, batch_duration_in_secs) {
  slack_client.notify("Book import batch progress at #{current_batch_number} of #{num_batches}") if (current_batch_number % 10).zero? # only every 10th batch

  web_sock.post("progress_bar", "Importing #{rows_size} rows. #{current_batch_number.to_f / num_batches * 100}% complete")
}

Book.import columns, books, batch_size: 2, batch_progress: my_proc
```

I hope you like the change, and deem it useful enough to be added to this project. Please let me know if there's anything you would like me to change.