### PR TITLE
Add support for compound foreign keys

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -160,6 +160,26 @@ describe "#import" do
         end
       end
     end
+
+    describe "with composite foreign keys" do
+      let(:account_id) { 555 }
+      let(:customer) { Customer.new(account_id: account_id, name: "foo") }
+      let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
+
+      it "imports and correctly maps foreign keys" do
+        assert_difference "Customer.count", +1 do
+          Customer.import [customer]
+        end
+
+        assert_difference "Order.count", +1 do
+          Order.import [order]
+        end
+
+        db_customer = Customer.last
+        db_order = Order.last
+        assert_equal db_customer.orders.last, db_order
+      end
+    end
   end
 
   describe "with STI models" do

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -177,7 +177,13 @@ describe "#import" do
 
         db_customer = Customer.last
         db_order = Order.last
-        assert_equal db_customer.orders.last, db_order
+
+        if %w(mysql2 mysql2_makara mysql2spatial seamless_database_pool spatialite sqlite3).include?(ENV["ARE_DB"])
+          assert_equal db_order.customer_id, nil
+        else
+          assert_equal db_customer.orders.last, db_order
+          assert_not_equal db_order.customer_id, nil
+        end
       end
     end
   end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -160,32 +160,6 @@ describe "#import" do
         end
       end
     end
-
-    describe "with composite foreign keys" do
-      let(:account_id) { 555 }
-      let(:customer) { Customer.new(account_id: account_id, name: "foo") }
-      let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
-
-      it "imports and correctly maps foreign keys" do
-        assert_difference "Customer.count", +1 do
-          Customer.import [customer]
-        end
-
-        assert_difference "Order.count", +1 do
-          Order.import [order]
-        end
-
-        db_customer = Customer.last
-        db_order = Order.last
-
-        if %w(mysql2 mysql2_makara mysql2spatial seamless_database_pool spatialite sqlite3).include?(ENV["ARE_DB"])
-          assert_equal db_order.customer_id, nil
-        else
-          assert_equal db_customer.orders.last, db_order
-          assert_not_equal db_order.customer_id, nil
-        end
-      end
-    end
   end
 
   describe "with STI models" do

--- a/test/models/customer.rb
+++ b/test/models/customer.rb
@@ -1,6 +1,6 @@
 class Customer < ActiveRecord::Base
   has_many :orders,
-           inverse_of: :customer,
-           primary_key: %i[account_id id],
-           foreign_key: %i[account_id customer_id]
+    inverse_of: :customer,
+    primary_key: %i[account_id id],
+    foreign_key: %i[account_id customer_id]
 end

--- a/test/models/customer.rb
+++ b/test/models/customer.rb
@@ -1,6 +1,6 @@
 class Customer < ActiveRecord::Base
   has_many :orders,
     inverse_of: :customer,
-    primary_key: %i[account_id id],
-    foreign_key: %i[account_id customer_id]
+    primary_key: %i(account_id id),
+    foreign_key: %i(account_id customer_id)
 end

--- a/test/models/customer.rb
+++ b/test/models/customer.rb
@@ -1,0 +1,6 @@
+class Customer < ActiveRecord::Base
+  has_many :orders,
+           inverse_of: :customer,
+           primary_key: %i[account_id id],
+           foreign_key: %i[account_id customer_id]
+end

--- a/test/models/order.rb
+++ b/test/models/order.rb
@@ -1,0 +1,6 @@
+class Order < ActiveRecord::Base
+  belongs_to :customer,
+             inverse_of: :orders,
+             primary_key: %i[account_id id],
+             foreign_key: %i[account_id customer_id]
+end

--- a/test/models/order.rb
+++ b/test/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ActiveRecord::Base
   belongs_to :customer,
-             inverse_of: :orders,
-             primary_key: %i[account_id id],
-             foreign_key: %i[account_id customer_id]
+    inverse_of: :orders,
+    primary_key: %i[account_id id],
+    foreign_key: %i[account_id customer_id]
 end

--- a/test/models/order.rb
+++ b/test/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ActiveRecord::Base
   belongs_to :customer,
     inverse_of: :orders,
-    primary_key: %i[account_id id],
-    foreign_key: %i[account_id customer_id]
+    primary_key: %i(account_id id),
+    foreign_key: %i(account_id customer_id)
 end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -205,4 +205,15 @@ ActiveRecord::Schema.define do
       );
     ).split.join(' ').strip
   end
+
+  create_table :customers, force: :cascade do |t|
+    t.integer :account_id
+    t.string :name
+  end
+
+  create_table :orders, force: :cascade do |t|
+    t.integer :account_id
+    t.integer :customer_id
+    t.integer :amount
+  end
 end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -78,21 +78,25 @@ def should_support_postgresql_import_functionality
       end
     end
 
-    describe "with compound foreign keys" do
-      let(:account_id) { 555 }
-      let(:customer) { Customer.new(account_id: account_id, name: "foo") }
-      let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
+    unless ENV["SKIP_COMPOSITE_PK"]
+      describe "with compound foreign keys" do
+        let(:account_id) { 555 }
+        let(:customer) { Customer.new(account_id: account_id, name: "foo") }
+        let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
 
-      it "imports and correctly maps foreign keys" do
-        assert_difference "Customer.count", +1 do
-          Customer.import [customer]
+        it "imports and correctly maps foreign keys" do
+          assert_difference "Customer.count", +1 do
+            Customer.import [customer]
+          end
+
+          assert_difference "Order.count", +1 do
+            Order.import [order]
+          end
+
+          db_customer = Customer.last
+          db_order = Order.last
+          assert_equal db_customer.orders.last, db_order
         end
-
-        assert_difference "Order.count", +1 do
-          Order.import [order]
-        end
-
-        assert_equal Customer.last.orders.last, Order.last
       end
     end
 

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -78,28 +78,6 @@ def should_support_postgresql_import_functionality
       end
     end
 
-    unless ENV["SKIP_COMPOSITE_PK"]
-      describe "with compound foreign keys" do
-        let(:account_id) { 555 }
-        let(:customer) { Customer.new(account_id: account_id, name: "foo") }
-        let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
-
-        it "imports and correctly maps foreign keys" do
-          assert_difference "Customer.count", +1 do
-            Customer.import [customer]
-          end
-
-          assert_difference "Order.count", +1 do
-            Order.import [order]
-          end
-
-          db_customer = Customer.last
-          db_order = Order.last
-          assert_equal db_customer.orders.last, db_order
-        end
-      end
-    end
-
     describe "no_returning" do
       let(:books) { [Book.new(author_name: "foo", title: "bar")] }
 

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -78,6 +78,24 @@ def should_support_postgresql_import_functionality
       end
     end
 
+    describe "with compound foreign keys" do
+      let(:account_id) { 555 }
+      let(:customer) { Customer.new(account_id: account_id, name: "foo") }
+      let(:order) { Order.new(account_id: account_id, amount: 100, customer: customer) }
+
+      it "imports and correctly maps foreign keys" do
+        assert_difference "Customer.count", +1 do
+          Customer.import [customer]
+        end
+
+        assert_difference "Order.count", +1 do
+          Order.import [order]
+        end
+
+        assert_equal Customer.last.orders.last, Order.last
+      end
+    end
+
     describe "no_returning" do
       let(:books) { [Book.new(author_name: "foo", title: "bar")] }
 


### PR DESCRIPTION
We use partitioning and for this, we need to include a partition key into each request. Hence, we need to redefine simple `belongs_to`, `has_many` to have (foreign_key, partition_key) as association connection. For example, if we partition tables by `account_id` and we have two tables `customers` and `orders`:

```ruby
# == Schema Information
#
# Table name: customers
#
#  id          :integer          not null, primary key
#  account_id  :integer
#  name        :string

class Customer < ActiveRecord::Base
  has_many :orders,
           inverse_of: :customer,
           primary_key: %i[account_id id],
           foreign_key: %i[account_id customer_id]
end

# == Schema Information
#
# Table name: orders
#
#  id           :integer          not null, primary key
#  account_id   :integer
#  customer_id  :integer
#  amount       :integer

class Order < ActiveRecord::Base
  belongs_to :customer,
             inverse_of: :orders,
             primary_key: %i[account_id id],
             foreign_key: %i[account_id customer_id]
end
```

We will get account_id as part the generated SQL when associations are called:

```ruby
customer = Customer.where(account_id: 1).first
customer.orders
=> SELECT * FROM orders WHERE account_id = 1 AND customer_id = 10;
```

However, the import of orders using `activerecord-import` will fail on `load_association_ids` method.
This PR attempts to fix the issue by treating all associations as a compound association. To simplify/unify the code we convert a single key association to an array or association keys and then work with each individual key the same way we worked before.