### PR TITLE
ActiveRecord `#database_version` is a public method

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -203,8 +203,6 @@ module ActiveRecord::Import::PostgreSQLAdapter
     true
   end
 
-  private
-
   def database_version
     defined?(postgresql_version) ? postgresql_version : super
   end

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -166,8 +166,6 @@ module ActiveRecord::Import::SQLite3Adapter
     exception.is_a?(ActiveRecord::StatementInvalid) && exception.to_s.include?('duplicate key')
   end
 
-  private
-
   def database_version
     defined?(sqlite_version) ? sqlite_version : super
   end


### PR DESCRIPTION
Hello,

`#database_version` is a public method in Rails. By overriding it, and making it private `activerecord-import` have side effects on some Rails features. Like structure dump since https://github.com/rails/rails/pull/43216.

```
NoMethodError: private method `database_version' called for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x00007f8d71dc7480>
```

In this PR I make `database_version` public again.


Have a good day ☀️
