### PR TITLE
Call `ActiveRecord.default_timezone=` if possible

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -433,7 +433,8 @@ Should you wish to specify those columns, you may use the option `timestamps: fa
 
 However, it is also possible to set just `:created_at` in specific records. In this case despite using `timestamps: true`,  `:created_at` will be updated only in records where that field is `nil`. Same rule applies for record associations when enabling the option `recursive: true`.
 
-If you are using custom time zones, these will be respected when performing imports as well as long as `ActiveRecord::Base.default_timezone` is set, which for practically all Rails apps it is
+If you are using custom time zones, these will be respected when performing imports as well as long as `ActiveRecord::Base.default_timezone` is set, which for practically all Rails apps it is.
+NOTE: If you are using ActiveRecord 7.0 or later, please use `ActiveRecord.default_timezone` instead.
 
 ### Callbacks
 

--- a/benchmarks/benchmark.rb
+++ b/benchmarks/benchmark.rb
@@ -20,7 +20,11 @@ FileUtils.mkdir_p 'log'
 ActiveRecord::Base.configurations["test"] = YAML.load_file(File.join(benchmark_dir, "../test/database.yml"))[options.adapter]
 ActiveRecord::Base.logger = Logger.new("log/test.log")
 ActiveRecord::Base.logger.level = Logger::DEBUG
-ActiveRecord::Base.default_timezone = :utc
+if ActiveRecord.respond_to?(:default_timezone)
+  ActiveRecord.default_timezone = :utc
+else
+  ActiveRecord::Base.default_timezone = :utc
+end
 
 require "activerecord-import"
 ActiveRecord::Base.establish_connection(:test)

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -555,7 +555,11 @@ describe "#import" do
     context "when the timestamps columns are present" do
       setup do
         @existing_book = Book.create(title: "Fell", author_name: "Curry", publisher: "Bayer", created_at: 2.years.ago.utc, created_on: 2.years.ago.utc, updated_at: 2.years.ago.utc, updated_on: 2.years.ago.utc)
-        ActiveRecord::Base.default_timezone = :utc
+        if ActiveRecord.respond_to?(:default_timezone)
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         Timecop.freeze(time) do
           assert_difference "Book.count", +2 do
             Book.import %w(title author_name publisher created_at created_on updated_at updated_on), [["LDAP", "Big Bird", "Del Rey", nil, nil, nil, nil], [@existing_book.title, @existing_book.author_name, @existing_book.publisher, @existing_book.created_at, @existing_book.created_on, @existing_book.updated_at, @existing_book.updated_on]]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,7 +58,11 @@ else
   ActiveRecord::Base.configurations["test"] = YAML.load_file(test_dir.join("database.yml"))[adapter]
 end
 
-ActiveRecord::Base.default_timezone = :utc
+if ActiveRecord.respond_to?(:default_timezone)
+  ActiveRecord.default_timezone = :utc
+else
+  ActiveRecord::Base.default_timezone = :utc
+end
 
 require "activerecord-import"
 ActiveRecord::Base.establish_connection :test


### PR DESCRIPTION
This PR is a follow-up to #752.

The following deprecation warning is displayed when I run CI with Rails 7.0.
```
DEPRECATION WARNING: ActiveRecord::Base.default_timezone= is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone=` instead.
 (called from <top (required)> at /home/runner/work/activerecord-import/activerecord-import/test/test_helper.rb:61)
```
This PR will suppress it.