### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Set up databases
         run: |
           sudo /etc/init.d/mysql start
@@ -61,8 +62,6 @@ jobs:
           cp test/github/database.yml test/database.yml
         env:
           PGPASSWORD: postgres
-      - name: Install dependencies
-        run : AR_VERSION=${{ env.AR_VERSION }} bundle install
       - name: Run tests
         run: |
           bundle exec rake test:mysql2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,9 +50,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Setup Bundler 1.x for Ruby 2.3
-        if: ${{ matrix.ruby == '2.3' }}
-        run: echo "BUNDLER_VERSION=1.17.3" >> $GITHUB_ENV
       - name: Set up databases
         run: |
           sudo /etc/init.d/mysql start

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,5 +74,15 @@ jobs:
           bundle exec rake test:seamless_database_pool
           bundle exec rake test:spatialite
           bundle exec rake test:sqlite3
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      AR_VERSION: '7.0'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -44,10 +44,6 @@ platforms :jruby do
   gem "ruby-debug", "= 0.10.4"
 end
 
-platforms :mri_19 do
-  gem "debugger"
-end
-
 platforms :ruby do
   gem "pry-byebug"
   gem "pry", "~> 0.12.0"


### PR DESCRIPTION
* Remove consideration of Ruby 1.9 and 2.3 which are not supported 
* Enable ruby/setup-ruby's `bundler-cache` to use caching
* Split test and lint, and run RuboCop only once