### PR TITLE
CI against Ruby 3.0 and 3.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,15 +62,21 @@ jobs:
           cp test/github/database.yml test/database.yml
         env:
           PGPASSWORD: postgres
-      - name: Run tests
+      - name: Run tests with mysql2
         run: |
           bundle exec rake test:mysql2
           bundle exec rake test:mysql2_makara
           bundle exec rake test:mysql2spatial
+      - name: Run tests with postgresql
+        run: |
           bundle exec rake test:postgis
           bundle exec rake test:postgresql
           bundle exec rake test:postgresql_makara
+      - name: Run tests with seamless_database_pool
+        run: |
           bundle exec rake test:seamless_database_pool
+      - name: Run tests with sqlite
+        run: |
           bundle exec rake test:spatialite
           bundle exec rake test:sqlite3
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,7 @@ jobs:
       - name: Run tests with seamless_database_pool
         run: |
           bundle exec rake test:seamless_database_pool
+        if: ${{ matrix.ruby < '3.0' }}
       - name: Run tests with sqlite
         run: |
           bundle exec rake test:spatialite

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,15 +20,28 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7
+          - 3.1
         env:
-          - AR_VERSION: 7.0
+          - AR_VERSION: '7.0'
             RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: 6.1
             RUBYOPT: --enable-frozen-string-literal
-          - AR_VERSION: 6.0
-            RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: '3.0'
+            env:
+              AR_VERSION: '7.0'
+          - ruby: '3.0'
+            env:
+              AR_VERSION: 6.1
+          - ruby: 2.7
+            env:
+              AR_VERSION: '7.0'
+          - ruby: 2.7
+            env:
+              AR_VERSION: 6.1
+          - ruby: 2.7
+            env:
+              AR_VERSION: '6.0'
           - ruby: 2.6
             env:
               AR_VERSION: 5.2
@@ -37,7 +50,7 @@ jobs:
               AR_VERSION: 5.1
           - ruby: 2.4
             env:
-              AR_VERSION: 5.0
+              AR_VERSION: '5.0'
           - ruby: 2.4
             env:
               AR_VERSION: 4.2

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ end
 platforms :ruby do
   gem "pry-byebug"
   gem "pry", "~> 0.12.0"
-  gem "rb-readline"
 end
 
 if version >= 4.0

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ platforms :ruby do
   gem "mysql2",                 "~> #{mysql2_version}"
   gem "pg",                     "~> #{pg_version}"
   gem "sqlite3",                "~> #{sqlite3_version}"
-  gem "seamless_database_pool", "~> 1.0.20"
+  # seamless_database_pool requires Ruby ~> 2.0
+  gem "seamless_database_pool", "~> 1.0.20" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
 end
 
 platforms :jruby do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,11 @@ ActiveRecord::Base.logger = Logger.new("log/test.log")
 ActiveRecord::Base.logger.level = Logger::DEBUG
 
 if ENV['AR_VERSION'].to_f >= 6.0
-  yaml_config = YAML.load_file(test_dir.join("database.yml"))[adapter]
+  yaml_config = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.2.1')
+    YAML.safe_load_file(test_dir.join("database.yml"), aliases: true)[adapter]
+  else
+    YAML.load_file(test_dir.join("database.yml"))[adapter]
+  end
   config = ActiveRecord::DatabaseConfigurations::HashConfig.new("test", adapter, yaml_config)
   ActiveRecord::Base.configurations.configurations << config
 else


### PR DESCRIPTION
This PR adds the Ruby 3.0 and 3.1 to the CI matrix, and does the following:

* Split tests by DB to allow for skipping.
* Since [seamless_database_pool](https://github.com/bdurand/seamless_database_pool) requires Ruby ~> 2.0, skip installing it and running tests with it for Ruby 3.0+.
* Use `YAML.safe_load_file` to allow the use of aliases with Ruby 3.1.
* Remove `rb-readline` from Gemfile to suppress a bunch of warnings.
And I confirmed all CIs are green.