### PR TITLE
Fix importing models that are required to belong to models with composite primary keys

### DIFF
--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 gem 'activerecord', '~> 7.0.0'
+gem 'composite_primary_keys', '~> 14.0'

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -57,7 +57,7 @@ module ActiveRecord::Import #:nodoc:
           end
         end
 
-        filter.instance_variable_set(:@attributes, attrs)
+        filter.instance_variable_set(:@attributes, attrs.flatten)
 
         if @validate_callbacks.respond_to?(:chain, true)
           @validate_callbacks.send(:chain).tap do |chain|

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -161,6 +161,25 @@ describe "#import" do
           Tag.import columns, values, validate: false
         end
       end
+
+      it "should import models that are required to belong to models with composite primary keys" do
+        tag = Tag.create!(tag_id: 1, publisher_id: 1, tag: 'Mystery')
+        valid_tag_alias = TagAlias.new(tag_id: tag.tag_id, parent_id: tag.publisher_id, alias: 'Detective')
+        invalid_tag_aliases = [
+          TagAlias.new(tag_id: nil, parent_id: nil, alias: 'Detective'),
+          TagAlias.new(tag_id: tag.tag_id, parent_id: nil, alias: 'Detective'),
+          TagAlias.new(tag_id: nil, parent_id: tag.publisher_id, alias: 'Detective'),
+        ]
+
+        assert_difference "TagAlias.count", +1 do
+          TagAlias.import [valid_tag_alias]
+        end
+        invalid_tag_aliases.each do |invalid_tag_alias|
+          assert_no_difference "TagAlias.count" do
+            TagAlias.import [invalid_tag_alias]
+          end
+        end
+      end
     end
   end
 

--- a/test/models/tag.rb
+++ b/test/models/tag.rb
@@ -3,4 +3,5 @@
 class Tag < ActiveRecord::Base
   self.primary_keys = :tag_id, :publisher_id unless ENV["SKIP_COMPOSITE_PK"]
   has_many :books, inverse_of: :tag
+  has_many :tag_aliases, inverse_of: :tag
 end

--- a/test/models/tag_alias.rb
+++ b/test/models/tag_alias.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TagAlias < ActiveRecord::Base
+  belongs_to :tag, foreign_key: [:tag_id, :parent_id], required: true
+end

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -206,6 +206,12 @@ ActiveRecord::Schema.define do
           PRIMARY KEY (tag_id, publisher_id)
       );
     ).split.join(' ').strip
+
+    create_table :tag_aliases, force: :cascade do |t|
+      t.integer :tag_id, null: false
+      t.integer :parent_id, null: false
+      t.string :alias, null: false
+    end
   end
 
   create_table :customers, force: :cascade do |t|


### PR DESCRIPTION
Without this change, such imports fail with an error such as `TypeError: [:tag_id, :parent_id] is not a symbol nor a string`.

<details>
<summary><h4>Backtrace</h4></summary>
<pre>…/gems/activemodel-7.0.4/lib/active_model/validator.rb:150:in `block in validate'
…/gems/activemodel-7.0.4/lib/active_model/validator.rb:149:in `each'
…/gems/activemodel-7.0.4/lib/active_model/validator.rb:149:in `validate'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:423:in `block in make_lambda'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:199:in `block (2 levels) in halting'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:687:in `block (2 levels) in default_terminator'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:686:in `catch'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:686:in `block in default_terminator'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:200:in `block in halting'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:595:in `block in invoke_before'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:595:in `each'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:595:in `invoke_before'
…/activerecord-import/lib/activerecord-import/import.rb:104:in `block in valid_model?'
…/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:99:in `run_callbacks'
…/activerecord-import/lib/activerecord-import/import.rb:86:in `valid_model?'
…/activerecord-import/lib/activerecord-import/import.rb:598:in `block in import_helper'
…/activerecord-import/lib/activerecord-import/import.rb:593:in `each'
…/activerecord-import/lib/activerecord-import/import.rb:593:in `import_helper'
…/activerecord-import/lib/activerecord-import/import.rb:532:in `bulk_import'
…/activerecord-import/test/import_test.rb:175:in `block (4 levels) in &lt;top (required)&gt;'
…/gems/activesupport-7.0.4/lib/active_support/testing/assertions.rb:34:in `assert_nothing_raised'
…/gems/activesupport-7.0.4/lib/active_support/testing/assertions.rb:250:in `_assert_nothing_raised_or_warn'
…/gems/activesupport-7.0.4/lib/active_support/testing/assertions.rb:102:in `assert_difference'
…/activerecord-import/test/import_test.rb:174:in `block (3 levels) in &lt;top (required)&gt;'</pre>
</details>