### PR TITLE
Introduce support for alias attributes

### DIFF
--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord::Import::AbstractAdapter
       post_sql_statements = []
 
       if supports_on_duplicate_key_update? && options[:on_duplicate_key_update]
-        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update], options[:primary_key], options[:locking_column] )
+        post_sql_statements << sql_for_on_duplicate_key_update( table_name, options[:on_duplicate_key_update], options[:model], options[:primary_key], options[:locking_column] )
       elsif logger && options[:on_duplicate_key_update]
         logger.warn "Ignoring on_duplicate_key_update because it is not supported by the database."
       end

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -86,13 +86,12 @@ module ActiveRecord::Import::MysqlAdapter
   # in +args+.
   def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
     sql = ' ON DUPLICATE KEY UPDATE '.dup
-    arg = args.first
-    locking_column = args.last
+    arg, model, _primary_key, locking_column = args
     case arg
     when Array
-      sql << sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arg )
+      sql << sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, arg )
     when Hash
-      sql << sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, arg )
+      sql << sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, arg )
     when String
       sql << arg
     else
@@ -101,19 +100,24 @@ module ActiveRecord::Import::MysqlAdapter
     sql
   end
 
-  def sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arr ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, arr ) # :nodoc:
     results = arr.map do |column|
-      qc = quote_column_name( column )
+      original_column_name = model.attribute_alias?( column ) ? model.attribute_alias( column ) : column
+      qc = quote_column_name( original_column_name )
       "#{table_name}.#{qc}=VALUES(#{qc})"
     end
     increment_locking_column!(table_name, results, locking_column)
     results.join( ',' )
   end
 
-  def sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, hsh ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, hsh ) # :nodoc:
     results = hsh.map do |column1, column2|
-      qc1 = quote_column_name( column1 )
-      qc2 = quote_column_name( column2 )
+      original_column1_name = model.attribute_alias?( column1 ) ? model.attribute_alias( column1 ) : column1
+      qc1 = quote_column_name( original_column1_name )
+
+      original_column2_name = model.attribute_alias?( column2 ) ? model.attribute_alias( column2 ) : column2
+      qc2 = quote_column_name( original_column2_name )
+
       "#{table_name}.#{qc1}=VALUES( #{qc2} )"
     end
     increment_locking_column!(table_name, results, locking_column)

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -134,7 +134,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
   # Returns a generated ON CONFLICT DO UPDATE statement given the passed
   # in +args+.
   def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
-    arg, primary_key, locking_column = args
+    arg, model, primary_key, locking_column = args
     arg = { columns: arg } if arg.is_a?( Array ) || arg.is_a?( String )
     return unless arg.is_a?( Hash )
 
@@ -155,9 +155,9 @@ module ActiveRecord::Import::PostgreSQLAdapter
     sql << "#{conflict_target}DO UPDATE SET "
     case columns
     when Array
-      sql << sql_for_on_duplicate_key_update_as_array( table_name, locking_column, columns )
+      sql << sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, columns )
     when Hash
-      sql << sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, columns )
+      sql << sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, columns )
     when String
       sql << columns
     else
@@ -169,19 +169,24 @@ module ActiveRecord::Import::PostgreSQLAdapter
     sql
   end
 
-  def sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arr ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, arr ) # :nodoc:
     results = arr.map do |column|
-      qc = quote_column_name( column )
+      original_column_name = model.attribute_alias?( column ) ? model.attribute_alias( column ) : column
+      qc = quote_column_name( original_column_name )
       "#{qc}=EXCLUDED.#{qc}"
     end
     increment_locking_column!(table_name, results, locking_column)
     results.join( ',' )
   end
 
-  def sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, hsh ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, hsh ) # :nodoc:
     results = hsh.map do |column1, column2|
-      qc1 = quote_column_name( column1 )
-      qc2 = quote_column_name( column2 )
+      original_column1_name = model.attribute_alias?( column1 ) ? model.attribute_alias( column1 ) : column1
+      qc1 = quote_column_name( original_column1_name )
+
+      original_column2_name = model.attribute_alias?( column2 ) ? model.attribute_alias( column2 ) : column2
+      qc2 = quote_column_name( original_column2_name )
+
       "#{qc1}=EXCLUDED.#{qc2}"
     end
     increment_locking_column!(table_name, results, locking_column)

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -95,7 +95,7 @@ module ActiveRecord::Import::SQLite3Adapter
   # Returns a generated ON CONFLICT DO UPDATE statement given the passed
   # in +args+.
   def sql_for_on_duplicate_key_update( table_name, *args ) # :nodoc:
-    arg, primary_key, locking_column = args
+    arg, model, primary_key, locking_column = args
     arg = { columns: arg } if arg.is_a?( Array ) || arg.is_a?( String )
     return unless arg.is_a?( Hash )
 
@@ -116,9 +116,9 @@ module ActiveRecord::Import::SQLite3Adapter
     sql << "#{conflict_target}DO UPDATE SET "
     case columns
     when Array
-      sql << sql_for_on_duplicate_key_update_as_array( table_name, locking_column, columns )
+      sql << sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, columns )
     when Hash
-      sql << sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, columns )
+      sql << sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, columns )
     when String
       sql << columns
     else
@@ -130,19 +130,24 @@ module ActiveRecord::Import::SQLite3Adapter
     sql
   end
 
-  def sql_for_on_duplicate_key_update_as_array( table_name, locking_column, arr ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_array( table_name, model, locking_column, arr ) # :nodoc:
     results = arr.map do |column|
-      qc = quote_column_name( column )
+      original_column_name = model.attribute_alias?( column ) ? model.attribute_alias( column ) : column
+      qc = quote_column_name( original_column_name )
       "#{qc}=EXCLUDED.#{qc}"
     end
     increment_locking_column!(table_name, results, locking_column)
     results.join( ',' )
   end
 
-  def sql_for_on_duplicate_key_update_as_hash( table_name, locking_column, hsh ) # :nodoc:
+  def sql_for_on_duplicate_key_update_as_hash( table_name, model, locking_column, hsh ) # :nodoc:
     results = hsh.map do |column1, column2|
-      qc1 = quote_column_name( column1 )
-      qc2 = quote_column_name( column2 )
+      original_column1_name = model.attribute_alias?( column1 ) ? model.attribute_alias( column1 ) : column1
+      qc1 = quote_column_name( original_column1_name )
+
+      original_column2_name = model.attribute_alias?( column2 ) ? model.attribute_alias( column2 ) : column2
+      qc2 = quote_column_name( original_column2_name )
+
       "#{qc1}=EXCLUDED.#{qc2}"
     end
     increment_locking_column!(table_name, results, locking_column)

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Topic < ActiveRecord::Base
+  if ENV['AR_VERSION'].to_i >= 6.0
+    self.ignored_columns = [:priority]
+  end
+  alias_attribute :name, :title
+
   validates_presence_of :author_name
   validates :title, numericality: { only_integer: true }, on: :context_test
   validates :title, uniqueness: true

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define do
     t.boolean :approved, default: '1'
     t.integer :replies_count
     t.integer :parent_id
+    t.integer :priority, default: 0
     t.string :type
     t.datetime :created_at
     t.datetime :created_on

--- a/test/support/shared_examples/on_duplicate_key_update.rb
+++ b/test/support/shared_examples/on_duplicate_key_update.rb
@@ -176,6 +176,7 @@ def should_support_basic_on_duplicate_key_update
             assert_equal 1, maker.lock_version
           end
         end
+
         it 'update the lock_version of models separated by namespaces by array' do
           makers = [
             Bike::Maker.new(name: 'Yamaha'),
@@ -315,6 +316,34 @@ def should_support_basic_on_duplicate_key_update
           let(:update_columns) { [:title, :author_email_address, :parent_id] }
           should_support_on_duplicate_key_update
           should_update_fields_mentioned
+        end
+
+        context "using column aliases" do
+          let(:columns) { %w( id title author_name author_email_address parent_id ) }
+          let(:update_columns) { %w(title author_email_address parent_id) }
+
+          context "with column aliases in column list" do
+            let(:columns) { %w( id name author_name author_email_address parent_id ) }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
+
+          context "with column aliases in update columns list" do
+            let(:update_columns) { %w(name author_email_address parent_id) }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
+        end
+
+        if ENV['AR_VERSION'].to_i >= 6.0
+          context "using ignored columns" do
+            let(:columns) { %w( id title author_name author_email_address parent_id priority ) }
+            let(:values) { [[99, "Book", "John Doe", "john@doe.com", 17, 1]] }
+            let(:update_columns) { %w(name author_email_address parent_id priority) }
+            let(:updated_values) { [[99, "Book - 2nd Edition", "Author Should Not Change", "johndoe@example.com", 57, 2]] }
+            should_support_on_duplicate_key_update
+            should_update_fields_mentioned
+          end
         end
       end
 


### PR DESCRIPTION
Probably it's related to issues:
https://github.com/zdennis/activerecord-import/issues/728:
```
class MyModel < ActiveRecord::Base
  alias_attribute :foo, :baz
end

MyModel.import(%i[foo bar], %w[value_foo, value_baz], validate: false, on_duplicate_key_update: { conflict_target: %i[bar], columns: %i[foo] })
```

https://github.com/zdennis/activerecord-import/issues/795:
```
class MyModel < ActiveRecord::Base
  self.ignored_columns = [:bar]
end

MyModel.import(%i[foo bar], %w[value_foo, value_baz], validate: false, on_duplicate_key_ignore: true)
MyModel.import(%i[foo bar], %w[value_foo, value_baz], validate: false, on_duplicate_key_update: { conflict_target: %i[foo], columns: %i[bar] })
```