### PR TITLE
Support for multi-byte column names when splitting queries

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -20,7 +20,7 @@ module ActiveRecord::Import::MysqlAdapter
                            [sql.shift, sql.join( ' ' )]
     end
 
-    sql_size = QUERY_OVERHEAD + base_sql.size + post_sql.size
+    sql_size = QUERY_OVERHEAD + base_sql.bytesize + post_sql.bytesize
 
     # the number of bytes the requested insert statement values will take up
     values_in_bytes = values.sum(&:bytesize)


### PR DESCRIPTION
Hello !
Query splitting does not work well when column names contain multibyte characters.
Here is an example of a table schema that causes problems.
```
create_table :topics, force: :cascade do |t|
    t.string 'あいう'  
end
```