### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,13 +20,19 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.1
+          - 3.2
         env:
           - AR_VERSION: '7.0'
             RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: 6.1
             RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: 3.1
+            env:
+              AR_VERSION: '7.0'
+          - ruby: 3.1
+            env:
+              AR_VERSION: 6.1
           - ruby: '3.0'
             env:
               AR_VERSION: '7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ end
 
 platforms :ruby do
   gem "pry-byebug"
-  gem "pry", "~> 0.12.0"
+  gem "pry", "~> 0.14.0"
 end
 
 if version >= 4.0


### PR DESCRIPTION
This PR adds Ruby 3.2 to the test matrix.

Also, update `pry`  to the latest version to support Ruby 3.2.
Ref: https://github.com/pry/pry/blob/master/CHANGELOG.md#v0142v0142-january-9-2023