### PR TITLE
Feature:  Add Dockerfile and compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Ruby 3.2 image as a base image
+ARG RUBY_VERSION=3.2
+FROM ruby:${RUBY_VERSION}-bullseye
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Install system packages
+RUN apt-get update -qq && \
+    apt-get install -y default-mysql-client vim && \
+    apt-get clean
+
+# Set environment variables
+ENV AR_VERSION=7.0
+
+# Copy all files
+COPY . .
+
+# Move sample database.yml and install gems
+RUN mv test/database.yml.sample test/database.yml && \
+    bundle install
+
+CMD ["irb"]

--- a/README.markdown
+++ b/README.markdown
@@ -626,6 +626,19 @@ AR_VERSION=7.0 bundle exec rake test:postgresql test:sqlite3 test:mysql2
 
 Once you have pushed up your changes, you can find your CI results [here](https://github.com/zdennis/activerecord-import/actions).
 
+#### Docker Setup
+
+Before you begin, make sure you have [Docker](https://www.docker.com/products/docker-desktop/) and [Docker Compose](https://docs.docker.com/compose/) installed on your machine. If you don't, you can install both via Homebrew using the following command:
+
+```bash
+brew install docker && brew install docker-compose
+```
+##### Steps
+
+1. In your terminal run `docker-compose up --build`
+1. In another tab/window run `docker-compose exec app bash`
+1. In that same terminal run the mysql2 test by running `bundle exec rake test:mysql2`
+
 ## Issue Triage [![Open Source Helpers](https://www.codetriage.com/zdennis/activerecord-import/badges/users.svg)](https://www.codetriage.com/zdennis/activerecord-import)
 
 You can triage issues which may include reproducing bug reports or asking for vital information, such as version numbers or reproduction instructions. If you would like to start triaging issues, one easy way to get started is to [subscribe to activerecord-import on CodeTriage](https://www.codetriage.com/zdennis/activerecord-import).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.5"
+
+services:
+  mysql:
+    platform: linux/x86_64
+    image: mysql:5.7
+    volumes:
+      - mysql-data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  app:
+    build:
+      context: .
+    environment:
+      DB_HOST: mysql
+      AR_VERSION: 7.0
+    volumes:
+      - .:/usr/src/app
+    depends_on:
+      - mysql
+    command: tail -f /dev/null
+
+volumes:
+  mysql-data:

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -8,6 +8,7 @@ common: &common
 mysql2: &mysql2
   <<: *common
   adapter: mysql2
+  host: mysql
 
 mysql2spatial:
   <<: *mysql2


### PR DESCRIPTION
# Purpose
Make it easier for people to develop using Docker.

# Implementation
Add a Dockerfile and docker-compose.yml to help developers be able to pull an image and run the application locally. You can read the README for how to do this. I went for the most minimal change to get mysql working first.

# Potential future work
The next step would be to add `postgresql` as a service so someone can run the tests against that database service.