### PR TITLE
Feature:  add postgresql to Docker and docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 
 # Install system packages
 RUN apt-get update -qq && \
-    apt-get install -y default-mysql-client vim && \
+    apt-get install -y default-mysql-client postgresql postgresql-contrib vim && \
     apt-get clean
 
 # Set environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,13 @@ services:
     ports:
       - "3306:3306"
 
+  postgresql:
+    image: postgres:latest
+    volumes:
+      - postgresql-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
   app:
     build:
       context: .
@@ -19,7 +26,9 @@ services:
       - .:/usr/src/app
     depends_on:
       - mysql
+      - postgresql
     command: tail -f /dev/null
 
 volumes:
   mysql-data:
+  postgresql-data:

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -20,6 +20,7 @@ postgresql: &postgresql
   <<: *common
   username: postgres
   adapter: postgresql
+  host: postgresql
   min_messages: warning
 
 postresql_makara:

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -147,7 +147,7 @@ def should_support_recursive_import
       end
 
       books.each do |book|
-        assert_equal book.topic_id, nil
+        assert_nil book.topic_id, nil
       end
     end
 


### PR DESCRIPTION
# Purpose
Add Postgresql to the Dockerfile and docker-compose.yml

# Implementation
Add necessary packages to the Dockerfile and add postgresql as a service. I also took the opportunity of fix a deprecation warning in the project around a minitest assertion
<img width="1176" alt="Screenshot 2023-09-04 at 7 43 11 AM" src="https://github.com/zdennis/activerecord-import/assets/10590756/42136b3f-c217-4f5f-8548-31e7a831f329">

