### PR TITLE
Import breaks when two column backed attributes are aliased together

### DIFF
--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -991,4 +991,16 @@ describe "#import" do
       end
     end
   end
+
+  describe "aliased attributes" do
+    it "two column based attributes can be imported" do
+      topic = FactoryBot.create :topic
+      new_topic = Topic.new(topic.attributes.except("id"))
+      new_topic.author_name = "John Doe"
+
+      Topic.import([new_topic])
+      assert_equal 2, Topic.count
+    end
+  end
+
 end

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -5,6 +5,7 @@ class Topic < ActiveRecord::Base
     self.ignored_columns = [:priority]
   end
   alias_attribute :name, :title
+  alias_attribute :author_full_name, :author_name
 
   validates_presence_of :author_name
   validates :title, numericality: { only_integer: true }, on: :context_test

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define do
     t.datetime :created_on
     t.datetime :updated_at
     t.datetime :updated_on
+    t.string :author_full_name
   end
 
   create_table :projects, force: :cascade do |t|


### PR DESCRIPTION
When a record has two column backed attributes that are aliased together, import breaks across the board because both column names are provided. I briefly looked to see if this was a code smell in ActiveRecord but have not been able to find anything definitive either way.

Take the following:

```ruby
create_table :topics, force: :cascade do |t|
  t.string :author_name
  t.string :author_full_name
end

class Topic < ActiveRecord::Base
  alias_attribute :author_full_name, :author_name
end
```

When the record is trying to be imported. `author_name` will be specified twice in the import string.