### PR TITLE
CI against Rails 7.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,16 @@ jobs:
         ruby:
           - 3.2
         env:
+          - AR_VERSION: '7.1'
+            RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: '7.0'
             RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: 6.1
             RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: 3.1
+            env:
+              AR_VERSION: '7.1'
           - ruby: 3.1
             env:
               AR_VERSION: '7.0'

--- a/gemfiles/7.1.gemfile
+++ b/gemfiles/7.1.gemfile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+gem 'activerecord', '~> 7.1.0'

--- a/test/schema/generic_schema.rb
+++ b/test/schema/generic_schema.rb
@@ -2,8 +2,10 @@
 
 ActiveRecord::Schema.define do
   create_table :schema_info, force: :cascade do |t|
-    t.integer :version, unique: true
+    t.integer :version
   end
+  add_index :schema_info, :version, unique: true
+
   SchemaInfo.create version: SchemaInfo::VERSION
 
   create_table :group, force: :cascade do |t|


### PR DESCRIPTION
This PR adds Rails 7.1. to the CI matrix.
I didn't add `composite_primary_keys` gem to Gemfile because it doesn't support Rails 7.1 yet. Ref: [Is gem still relevant with Rails 7.1?](https://github.com/composite-primary-keys/composite_primary_keys/issues/608)