### PR TITLE
Bump `Checkout` action to V4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
       AR_VERSION: ${{ matrix.env.AR_VERSION }}
       DB_DATABASE: activerecord_import_test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -110,7 +110,7 @@ jobs:
     env:
       AR_VERSION: '7.0'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7


### PR DESCRIPTION
The `Checkout` action V2 uses old Node.js. It causes a lot of warnings and bump version to fix those.

Ref: "Annotations" section in https://github.com/zdennis/activerecord-import/actions/runs/6556382678