### PR TITLE
Use ActiveRecord::Base.locking_enabled? to update the lock field

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -557,7 +557,7 @@ class ActiveRecord::Base
       options.merge!( args.pop ) if args.last.is_a? Hash
       # making sure that current model's primary key is used
       options[:primary_key] = primary_key
-      options[:locking_column] = locking_column if attribute_names.include?(locking_column)
+      options[:locking_column] = locking_column if locking_enabled?
 
       is_validating = options[:validate_with_context].present? ? true : options[:validate]
       validator = ActiveRecord::Import::Validator.new(self, options)


### PR DESCRIPTION
### Problem

`activerecord-import` is ignoring the [`ActiveRecord::Base.lock_optimistically = false`](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) flag and it still updates the lock field.

### Solution

Use the [`locking_enabled?`](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic/ClassMethods.html#method-i-locking_enabled-3F) method provided by activerecord to decide whether the lock field should be updated.