### PR TITLE
[Feature]  Add trilogy adapter support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,6 +95,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          rubygems: latest
       - name: Set up databases
         run: |
           sudo /etc/init.d/mysql start

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: github
+          MYSQL_PASSWORD: github
+          MYSQL_DATABASE: activerecord_import_test
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -110,6 +124,9 @@ jobs:
         run: |
           bundle exec rake test:spatialite
           bundle exec rake test:sqlite3
+      - name: Run trilogy tests
+        if: ${{ matrix.env.AR_VERSION >= '7.0' }}
+        run: bundle exec rake test:trilogy
   lint:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
           bundle exec rake test:spatialite
           bundle exec rake test:sqlite3
       - name: Run trilogy tests
-        if: ${{ matrix.env.AR_VERSION >= '7.0' }}
+        if: ${{ matrix.env.AR_VERSION >= '7.0' && matrix.ruby != 'jruby' }}
         run: bundle exec rake test:trilogy
   lint:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ platforms :ruby do
   gem "sqlite3",                "~> #{sqlite3_version}"
   # seamless_database_pool requires Ruby ~> 2.0
   gem "seamless_database_pool", "~> 1.0.20" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
+  gem "trilogy" if version >= 6.1
+  gem "activerecord-trilogy-adapter" if version >= 6.1
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,11 @@ platforms :jruby do
 end
 
 # Support libs
-gem "factory_bot"
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
+  gem "factory_bot"
+else
+  gem "factory_bot", "~> 6.2", "< 6.4.5"
+end
 gem "timecop"
 gem "chronic"
 gem "mocha", "~> 2.1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ platforms :ruby do
   # seamless_database_pool requires Ruby ~> 2.0
   gem "seamless_database_pool", "~> 1.0.20" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
   gem "trilogy" if version >= 6.1
-  gem "activerecord-trilogy-adapter" if version <= 7.0
+  if version >= 6.0 && version <= 7.0
+    gem "activerecord-trilogy-adapter"
+  end
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ platforms :ruby do
   gem "sqlite3",                "~> #{sqlite3_version}"
   # seamless_database_pool requires Ruby ~> 2.0
   gem "seamless_database_pool", "~> 1.0.20" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
-  gem "trilogy" if version >= 6.1
+  gem "trilogy" if version >= 6.0
   if version >= 6.0 && version <= 7.0
     gem "activerecord-trilogy-adapter"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ platforms :ruby do
   # seamless_database_pool requires Ruby ~> 2.0
   gem "seamless_database_pool", "~> 1.0.20" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
   gem "trilogy" if version >= 6.1
-  gem "activerecord-trilogy-adapter" if version >= 6.1
+  gem "activerecord-trilogy-adapter" if version <= 7.0
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
   gem "factory_bot"
 else
-  gem "factory_bot", "~> 6.2", "< 6.4.5"
+  gem "factory_bot", "~> 5", "< 6.4.5"
 end
 gem "timecop"
 gem "chronic"

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ ADAPTERS = %w(
   sqlite3
   spatialite
   seamless_database_pool
+  trilogy
 ).freeze
 ADAPTERS.each do |adapter|
   namespace :test do

--- a/lib/activerecord-import/active_record/adapters/trilogy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/trilogy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/trilogy_adapter"
+require "activerecord-import/adapters/trilogy_adapter"
+
+class ActiveRecord::ConnectionAdapters::TrilogyAdapter
+  include ActiveRecord::Import::TrilogyAdapter
+end

--- a/lib/activerecord-import/adapters/trilogy_adapter.rb
+++ b/lib/activerecord-import/adapters/trilogy_adapter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/mysql_adapter"
+
+module ActiveRecord::Import::TrilogyAdapter
+  include ActiveRecord::Import::MysqlAdapter
+end

--- a/test/adapters/trilogy.rb
+++ b/test/adapters/trilogy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# ensure we connect to the trilogy adapter
+if ENV['AR_VERSION'].to_f >= 7.1
+  ENV["ARE_DB"] = "trilogy"
+else
+  require "activerecord-trilogy-adapter"
+  require "trilogy_adapter/connection"
+  ActiveRecord::Base.extend TrilogyAdapter::Connection
+  ENV["ARE_DB"] = "trilogy"
+end

--- a/test/adapters/trilogy.rb
+++ b/test/adapters/trilogy.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# ensure we connect to the trilogy adapter
-if ENV['AR_VERSION'].to_f >= 7.1
-  ENV["ARE_DB"] = "trilogy"
-else
+ENV["ARE_DB"] = "trilogy"
+
+if ENV['AR_VERSION'].to_f <= 7.0
   require "activerecord-trilogy-adapter"
   require "trilogy_adapter/connection"
   ActiveRecord::Base.extend TrilogyAdapter::Connection
-  ENV["ARE_DB"] = "trilogy"
 end

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -52,3 +52,8 @@ sqlite3: &sqlite3
 
 spatialite:
   <<: *sqlite3
+
+trilogy:
+  <<: *common
+  adapter: trilogy
+  host: mysql

--- a/test/github/database.yml
+++ b/test/github/database.yml
@@ -66,3 +66,7 @@ sqlite3: &sqlite3
 
 spatialite:
   <<: *sqlite3
+
+trilogy:
+  <<: *common
+  adapter: trilogy

--- a/test/trilogy/import_test.rb
+++ b/test/trilogy/import_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require File.expand_path("#{File.dirname(__FILE__)}/../test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/../support/assertions")
+require File.expand_path("#{File.dirname(__FILE__)}/../support/mysql/import_examples")
+
+should_support_mysql_import_functionality


### PR DESCRIPTION
# Purpose

Bring support for the [Trilogy adapter](https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/)to this project. I work on a Rails project and would like to switch to this new adapter. When running our CI I discovered this gem didn’t have support. Which then pointed to a child dependency that needed that support. I added that [here](https://github.com/composite-primary-keys/composite_primary_keys/pull/607).