### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.2
+          - 3.3
         env:
           - AR_VERSION: '7.1'
             RUBYOPT: --enable-frozen-string-literal
@@ -43,6 +43,15 @@ jobs:
           - AR_VERSION: 6.1
             RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: 3.2
+            env:
+              AR_VERSION: '7.1'
+          - ruby: 3.2
+            env:
+              AR_VERSION: '7.0'
+          - ruby: 3.2
+            env:
+              AR_VERSION: 6.1
           - ruby: 3.1
             env:
               AR_VERSION: '7.1'


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix to ensure `activerecord-import` work with Ruby 3.3