### PR TITLE
Fix jruby spec runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
           bundle exec rake test:spatialite
           bundle exec rake test:sqlite3
       - name: Run trilogy tests
-        if: ${{ matrix.env.AR_VERSION >= '7.0' && matrix.ruby != 'jruby' }}
+        if: ${{ matrix.env.AR_VERSION >= '7.0' && !startsWith(matrix.ruby, 'jruby') }}
         run: bundle exec rake test:trilogy
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Purpose
With the new release of this gem we updated the version of jruby https://github.com/zdennis/activerecord-import/commit/0b22f67d5d0f69f86244de8caee658ba80b56430. 

# Fix
We were currently matching on `jruby`, but let's make sure we never run against `jruby` if the  matrix ruby contains `jruby`.