### PR TITLE
Rails 71 composite pks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,16 @@ tmtags
 ## VIM
 *.swp
 
+## Idea
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc
 pkg
 *.gem
 *.lock
+.byebug_history
 
 ## PROJECT::SPECIFIC
 log/*.log

--- a/test/models/author.rb
+++ b/test/models/author.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Author < ActiveRecord::Base
+  if ENV['AR_VERSION'].to_f >= 7.1
+    has_many :composite_books, query_constraints: [:id, :author_id], inverse_of: :author
+  end
+end

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -2,8 +2,11 @@
 
 class Book < ActiveRecord::Base
   belongs_to :topic, inverse_of: :books
-  belongs_to :tag, foreign_key: [:tag_id, :parent_id] unless ENV["SKIP_COMPOSITE_PK"]
-
+  if ENV['AR_VERSION'].to_f <= 7.0
+    belongs_to :tag, foreign_key: [:tag_id, :parent_id] unless ENV["SKIP_COMPOSITE_PK"]
+  else
+    belongs_to :tag, query_constraints: [:tag_id, :parent_id] unless ENV["SKIP_COMPOSITE_PK"]
+  end
   has_many :chapters, inverse_of: :book
   has_many :discounts, as: :discountable
   has_many :end_notes, inverse_of: :book

--- a/test/models/composite_book.rb
+++ b/test/models/composite_book.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CompositeBook < ActiveRecord::Base
+  self.primary_key = %i[id author_id]
+  belongs_to :author
+  if ENV['AR_VERSION'].to_f <= 7.0
+    unless ENV["SKIP_COMPOSITE_PK"]
+      has_many :composite_chapters, inverse_of: :composite_book,
+                                    foreign_key: [:id, :author_id]
+    end
+  else
+    has_many :composite_chapters, inverse_of: :composite_book,
+                                  query_constraints: [:id, :author_id]
+  end
+
+  def self.sequence_name
+    "composite_book_id_seq"
+  end
+end

--- a/test/models/composite_chapter.rb
+++ b/test/models/composite_chapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CompositeChapter < ActiveRecord::Base
+  if ENV['AR_VERSION'].to_f >= 7.1
+    belongs_to :composite_book, inverse_of: :composite_chapters,
+                                query_constraints: [:composite_book_id, :author_id]
+  end
+  validates :title, presence: true
+end

--- a/test/models/customer.rb
+++ b/test/models/customer.rb
@@ -2,9 +2,17 @@
 
 class Customer < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    has_many :orders,
-      inverse_of: :customer,
-      primary_key: %i(account_id id),
-      foreign_key: %i(account_id customer_id)
+    if ENV['AR_VERSION'].to_f <= 7.0
+      has_many :orders,
+               inverse_of: :customer,
+               primary_key: %i(account_id id),
+               foreign_key: %i(account_id customer_id)
+    else
+      has_many :orders,
+               inverse_of: :customer,
+               primary_key: %i(account_id id),
+               query_constraints: %i(account_id customer_id)
+    end
+
   end
 end

--- a/test/models/order.rb
+++ b/test/models/order.rb
@@ -2,9 +2,16 @@
 
 class Order < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    belongs_to :customer,
-      inverse_of: :orders,
-      primary_key: %i(account_id id),
-      foreign_key: %i(account_id customer_id)
+    if ENV['AR_VERSION'].to_f <= 7.0
+      belongs_to :customer,
+                 inverse_of: :orders,
+                 primary_key: %i(account_id id),
+                 foreign_key: %i(account_id customer_id)
+    else
+      belongs_to :customer,
+                 inverse_of: :orders,
+                 primary_key: %i(account_id id),
+                 query_constraints: %i(account_id customer_id)
+    end
   end
 end

--- a/test/models/tag.rb
+++ b/test/models/tag.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class Tag < ActiveRecord::Base
-  self.primary_keys = :tag_id, :publisher_id unless ENV["SKIP_COMPOSITE_PK"]
+  if ENV['AR_VERSION'].to_f <= 7.0
+    self.primary_keys = :tag_id, :publisher_id unless ENV["SKIP_COMPOSITE_PK"]
+  else
+    self.primary_key = [:tag_id, :publisher_id] unless ENV["SKIP_COMPOSITE_PK"]
+  end
+  self.primary_key = [:tag_id, :publisher_id] unless ENV["SKIP_COMPOSITE_PK"]
   has_many :books, inverse_of: :tag
   has_many :tag_aliases, inverse_of: :tag
 end

--- a/test/models/tag_alias.rb
+++ b/test/models/tag_alias.rb
@@ -2,6 +2,10 @@
 
 class TagAlias < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    belongs_to :tag, foreign_key: [:tag_id, :parent_id], required: true
+    if ENV['AR_VERSION'].to_f <= 7.0
+      belongs_to :tag, foreign_key: [:tag_id, :parent_id], required: true
+    else
+      belongs_to :tag, query_constraints: [:tag_id, :parent_id], required: true
+    end
   end
 end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -351,6 +351,18 @@ def should_support_postgresql_import_functionality
         assert_equal db_customer.orders.last, db_order
         assert_not_equal db_order.customer_id, nil
       end
+
+      it "should import models with auto-incrementing ID successfully" do
+        author = Author.create!(name: "Foo Barson")
+
+        books = []
+        2.times do |i|
+          books << CompositeBook.new(author_id: author.id, title: "book #{i}")
+        end
+        assert_difference "CompositeBook.count", +2 do
+          CompositeBook.import books
+        end
+      end
     end
   end
 end

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -165,6 +165,24 @@ def should_support_recursive_import
           assert_equal 1, tags[0].tag_id
           assert_equal 2, tags[1].tag_id
         end
+
+        if ENV['AR_VERSION'].to_f >= 7.1
+          it "should import models with auto-incrementing ID successfully with recursive set to true" do
+            author = Author.create!(name: "Foo Barson")
+            books = []
+            2.times do |i|
+              books << CompositeBook.new(author_id: author.id, title: "Book #{i}", composite_chapters: [
+                                           CompositeChapter.new(title: "Book #{i} composite chapter 1"),
+                                           CompositeChapter.new(title: "Book #{i} composite chapter 2"),
+                                         ])
+            end
+            assert_difference "CompositeBook.count", +2 do
+              assert_difference "CompositeChapter.count", +4 do
+                CompositeBook.import books, recursive: true
+              end
+            end
+          end
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,9 @@ require 'chronic'
 begin
   require 'composite_primary_keys'
 rescue LoadError
-  ENV["SKIP_COMPOSITE_PK"] = "true"
+  if ENV['AR_VERSION'].to_f <= 7.1
+    ENV['SKIP_COMPOSITE_PK'] = 'true'
+  end
 end
 
 # Support MySQL 5.7


### PR DESCRIPTION
Adding support for Rails 7.1 composite primary keys (issue #830 )

For Rails 7.1 I am making the assumption that the [composite-primary-keys](https://github.com/composite-primary-keys/composite_primary_keys) gem is not going to be used, since Rails 7.1 has out-of-the-box support for composite PKs. I have added some inline comments in the PR for the reviewers.