### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -10,6 +10,10 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/zdennis/activerecord-import"
   gem.license       = "MIT"
 
+  gem.metadata = {
+    "changelog_uri" => "https://github.com/zdennis/activerecord-import/blob/master/CHANGELOG.md"
+  }
+
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater