### PR TITLE
Fix Ruby 3.3.5 warning - ostruct will no longer be part of the default gems

### DIFF
--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_runtime_dependency "activerecord", ">= 4.2"
+  gem.add_runtime_dependency "ostruct"
   gem.add_development_dependency "rake"
 end


### PR DESCRIPTION
Fixes the warning with Ruby 3.3.5:

warning: .../ruby/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add ostruct to your Gemfile or gemspec to silence this warning.

https://github.com/ruby/ruby/blob/v3_3_5/lib/bundled_gems.rb#L29