### PR TITLE
Remove OpenStruct

### DIFF
--- a/benchmarks/lib/base.rb
+++ b/benchmarks/lib/base.rb
@@ -16,7 +16,7 @@ class BenchmarkBase
     end
   end
 
-  # Returns an OpenStruct which contains two attritues, +description+ and +tms+ after performing an
+  # Returns a struct which contains two attritues, +description+ and +tms+ after performing an
   # actual benchmark.
   #
   # == PARAMETERS
@@ -24,9 +24,12 @@ class BenchmarkBase
   #  * blk - the block of code to benchmark
   #
   # == RETURNS
-  # An OpenStruct object with the following attributes:
+  # A struct object with the following attributes:
   #   * description - the description of the benchmark ran
   #   * tms - a Benchmark::Tms containing the results of the benchmark
+
+  BmStruct = Struct.new( :description, :tms, :failed, keyword_init: true )
+
   def bm( description, &block )
     tms = nil
     puts "Benchmarking #{description}"
@@ -35,7 +38,7 @@ class BenchmarkBase
     delete_all
     failed = false
 
-    OpenStruct.new description: description, tms: tms, failed: failed
+    BmStruct.new( description: description, tms: tms, failed: failed )
   end
 
   # Given a model class (ie: Topic), and an array of columns and value sets

--- a/benchmarks/lib/cli_parser.rb
+++ b/benchmarks/lib/cli_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'ostruct'
 
 #
 # == PARAMETERS
@@ -38,8 +37,11 @@ module BenchmarkOptionParser
     end
   end
 
+  OptionsStruct = Struct.new( :adapter, :table_types, :delete_on_finish, :number_of_objects, :outputs,
+                              :benchmark_all_types, keyword_init: true )
+  OutputStruct = Struct.new( :format, :filename, keyword_init: true )
   def self.parse( args )
-    options = OpenStruct.new(
+    options = OptionsStruct.new(
       adapter: 'mysql2',
       table_types: {},
       delete_on_finish: true,
@@ -81,12 +83,12 @@ module BenchmarkOptionParser
 
       # print results in CSV format
       opts.on( "--to-csv [String]", "Print results in a CSV file format" ) do |filename|
-        options.outputs << OpenStruct.new( format: 'csv', filename: filename)
+        options.outputs << OutputStruct.new( format: 'csv', filename: filename)
       end
 
       # print results in HTML format
       opts.on( "--to-html [String]", "Print results in HTML format" ) do |filename|
-        options.outputs << OpenStruct.new( format: 'html', filename: filename )
+        options.outputs << OutputStruct.new( format: 'html', filename: filename )
       end
     end # end opt.parse!
 
@@ -100,7 +102,7 @@ module BenchmarkOptionParser
     end
 
     options.number_of_objects = [1000] if options.number_of_objects.empty?
-    options.outputs = [OpenStruct.new( format: 'html', filename: 'benchmark.html')] if options.outputs.empty?
+    options.outputs = [OutputStruct.new( format: 'html', filename: 'benchmark.html')] if options.outputs.empty?
 
     print_options( options )
 

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 module ActiveRecord::Import::ConnectionAdapters; end
 
 module ActiveRecord::Import # :nodoc:


### PR DESCRIPTION
Fixes the warning with Ruby 3.3.5:
warning: .../ruby/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add ostruct to your Gemfile or gemspec to silence this warning.

OpenStruct use officially discouraged
https://docs.ruby-lang.org/en/master/NEWS/NEWS-3_0_0_md.html
https://docs.ruby-lang.org/en/master/OpenStruct.html#class-OpenStruct-label-Caveats