### PR TITLE
Fixing CI failures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
           - ruby: '3.0'
             env:
               AR_VERSION: 6.1
-          - ruby: jruby-9.4.5.0
+          - ruby: jruby-9.4.8.0
             env:
               AR_VERSION: '7.0'
           - ruby: 2.7
@@ -85,7 +85,7 @@ jobs:
           - ruby: 2.7
             env:
               AR_VERSION: '6.0'
-          - ruby: jruby-9.3.10.0
+          - ruby: jruby-9.3.15.0
             env:
               AR_VERSION: '6.1'
           - ruby: 2.6
@@ -142,6 +142,10 @@ jobs:
       AR_VERSION: '7.0'
     steps:
       - uses: actions/checkout@v4
+      - name: Install SQLite3 Development Library
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,6 +97,10 @@ jobs:
       DB_DATABASE: activerecord_import_test
     steps:
       - uses: actions/checkout@v4
+      - name: Install SQLite3 Development Library
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
The `ubuntu-latest` now uses the Ubuntu-24.04 image.
https://github.com/actions/runner-images/issues/10636

In the Ubuntu-24.04 image, `libsqlite3-dev`, which was installed in the Ubuntu 22.04 image, is no longer included.
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
Therefore, the installation of the `sqlite3` gem fails.
It is necessary to explicitly install the `libsqlite3-dev` package.

Since `jruby-9.4.5.0` and `jruby-9.3.10.0` for Ubuntu-24.04 do not exist, it is necessary to update them accordingly.
https://github.com/ruby/ruby-builder/releases