### PR TITLE
Remove legacy ActiveRecord version gemfiles (4.2, 5.0, 5.1)

### DIFF
--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-gem 'activerecord', '~> 4.2.0'
-gem 'composite_primary_keys', '~> 8.0'

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-gem 'activerecord', '~> 5.0.0'
-gem 'composite_primary_keys', '~> 9.0'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-gem 'activerecord', '~> 5.1.0'
-gem 'composite_primary_keys', '~> 10.0'


### PR DESCRIPTION
Removes gemfiles for ActiveRecord versions 4.2, 5.0, and 5.1 as they are not referenced in the `AR_VERSION` matrix of [`.github/workflows/test.yaml`](https://github.com/zdennis/activerecord-import/blob/b38064538c144e58c9cf59e9b7e4ece556389823/.github/workflows/test.yaml) . These gemfiles are not being used in our CI workflow.