### PR TITLE
Remove outdated ruby-debug requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,6 @@ gem "chronic"
 gem "mocha", "~> 2.1.0"
 
 # Debugging
-platforms :jruby do
-  gem "ruby-debug", "= 0.10.4"
-end
-
 platforms :ruby do
   gem "pry-byebug"
   gem "pry", "~> 0.14.0"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,8 +49,6 @@ if ActiveSupport::VERSION::STRING < "4.1"
   end
 end
 
-require "ruby-debug" if RUBY_VERSION.to_f < 1.9
-
 adapter = ENV["ARE_DB"] || "sqlite3"
 
 FileUtils.mkdir_p 'log'


### PR DESCRIPTION
This PR removes an outdated debugging requirement from our test helper and Gemfile. Because Our test matrix in [.github/workflows/test.yaml](https://github.com/zdennis/activerecord-import/blob/b38064538c144e58c9cf59e9b7e4ece556389823/.github/workflows/test.yaml) only includes Ruby versions 2.6 and above.

Additionally, JRuby will never meet the condition `RUBY_VERSION.to_f < 1.9`.
```
❯ mise exec ruby@jruby-9.4.8.0 -- ruby -e 'puts "#{JRUBY_VERSION}, #{RUBY_VERSION}"'
9.4.8.0, 3.1.4
❯ mise exec ruby@jruby-9.3.15.0 -- ruby -e 'puts "#{JRUBY_VERSION}, #{RUBY_VERSION}"'
9.3.15.0, 2.6.8
```