### PR TITLE
Remove legacy ActiveRecord version conditions from Gemfile and test files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gemspec
 
 version = ENV['AR_VERSION'].to_f
 
-mysql2_version = '0.3.0'
-mysql2_version = '0.4.0' if version >= 4.2
+mysql2_version = '0.4.0'
 mysql2_version = '0.5.0' if version >= 6.1
 mysql2_version = '0.5.6' if version >= 8.0
 sqlite3_version = '1.3.0'
@@ -59,10 +58,6 @@ platforms :ruby do
   gem "pry", "~> 0.14.0"
 end
 
-if version >= 4.0
-  gem "minitest"
-else
-  gem "test-unit"
-end
+gem "minitest"
 
 eval_gemfile File.expand_path("../gemfiles/#{version}.gemfile", __FILE__)

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -741,14 +741,8 @@ describe "#import" do
       ]
       Book.import books
       assert_equal 2, Book.count
-
-      if ENV['AR_VERSION'].to_i >= 5.0
-        assert_equal 'draft', Book.first.read_attribute('status')
-        assert_equal 'published', Book.last.read_attribute('status')
-      else
-        assert_equal 0, Book.first.read_attribute('status')
-        assert_equal 1, Book.last.read_attribute('status')
-      end
+      assert_equal 'draft', Book.first.read_attribute('status')
+      assert_equal 'published', Book.last.read_attribute('status')
     end
 
     it 'should be able to import enum fields with default value' do
@@ -758,32 +752,19 @@ describe "#import" do
       ]
       Book.import books
       assert_equal 1, Book.count
-
-      if ENV['AR_VERSION'].to_i >= 5.0
-        assert_equal 'draft', Book.first.read_attribute('status')
-      else
-        assert_equal 0, Book.first.read_attribute('status')
-      end
+      assert_equal 'draft', Book.first.read_attribute('status')
     end
 
-    if ENV['AR_VERSION'].to_f > 4.1
-      it 'should be able to import enum fields by name' do
-        Book.delete_all if Book.count > 0
-        books = [
-          Book.new(author_name: "Foo", title: "Baz", status: :draft),
-          Book.new(author_name: "Foo2", title: "Baz2", status: :published),
-        ]
-        Book.import books
-        assert_equal 2, Book.count
-
-        if ENV['AR_VERSION'].to_i >= 5.0
-          assert_equal 'draft', Book.first.read_attribute('status')
-          assert_equal 'published', Book.last.read_attribute('status')
-        else
-          assert_equal 0, Book.first.read_attribute('status')
-          assert_equal 1, Book.last.read_attribute('status')
-        end
-      end
+    it 'should be able to import enum fields by name' do
+      Book.delete_all if Book.count > 0
+      books = [
+        Book.new(author_name: "Foo", title: "Baz", status: :draft),
+        Book.new(author_name: "Foo2", title: "Baz2", status: :published),
+      ]
+      Book.import books
+      assert_equal 2, Book.count
+      assert_equal 'draft', Book.first.read_attribute('status')
+      assert_equal 'published', Book.last.read_attribute('status')
     end
   end
 
@@ -796,13 +777,8 @@ describe "#import" do
       Book.import columns, values
       assert_equal 2, Book.count
 
-      if ENV['AR_VERSION'].to_i >= 5.0
-        assert_equal 'draft', Book.first.read_attribute('status')
-        assert_equal 'published', Book.last.read_attribute('status')
-      else
-        assert_equal 0, Book.first.read_attribute('status')
-        assert_equal 1, Book.last.read_attribute('status')
-      end
+      assert_equal 'draft', Book.first.read_attribute('status')
+      assert_equal 'published', Book.last.read_attribute('status')
     end
   end
 

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -12,7 +12,7 @@ class Book < ActiveRecord::Base
   has_many :end_notes, inverse_of: :book
   if ENV['AR_VERSION'].to_f >= 8.0
     enum :status, [:draft, :published]
-  elsif ENV['AR_VERSION'].to_f >= 4.1
+  else
     enum status: [:draft, :published]
   end
 end

--- a/test/support/active_support/test_case_extensions.rb
+++ b/test/support/active_support/test_case_extensions.rb
@@ -3,11 +3,7 @@
 class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures
 
-  if ENV['AR_VERSION'].to_f >= 5.0
-    self.use_transactional_tests = true
-  else
-    self.use_transactional_fixtures = true
-  end
+  self.use_transactional_tests = true
 
   class << self
     def requires_active_record_version(version_string, &blk)

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -84,14 +84,12 @@ def should_support_mysql_import_functionality
       end
     end
 
-    if ENV['AR_VERSION'].to_f >= 5.1
-      context "with virtual columns" do
-        let(:books) { [Book.new(author_name: "foo", title: "bar")] }
+    context "with virtual columns" do
+      let(:books) { [Book.new(author_name: "foo", title: "bar")] }
 
-        it "ignores virtual columns and creates record" do
-          assert_difference "Book.count", +1 do
-            Book.import books
-          end
+      it "ignores virtual columns and creates record" do
+        assert_difference "Book.count", +1 do
+          Book.import books
         end
       end
     end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -38,10 +38,8 @@ def should_support_postgresql_import_functionality
         assert !topic.changed?
       end
 
-      if ENV['AR_VERSION'].to_f > 4.1
-        it "moves the dirty changes to previous_changes" do
-          assert topic.previous_changes.present?
-        end
+      it "moves the dirty changes to previous_changes" do
+        assert topic.previous_changes.present?
       end
 
       it "marks models as persisted" do
@@ -96,15 +94,9 @@ def should_support_postgresql_import_functionality
     describe "returning" do
       let(:books) { [Book.new(author_name: "King", title: "It")] }
       let(:result) { Book.import(books, returning: %w(author_name title)) }
-      let(:book_id) do
-        if RUBY_PLATFORM == 'java' || ENV['AR_VERSION'].to_i >= 5.0
-          books.first.id
-        else
-          books.first.id.to_s
-        end
-      end
-      let(:true_returning_value) { ENV['AR_VERSION'].to_f >= 5.0 ? true : 't' }
-      let(:false_returning_value) { ENV['AR_VERSION'].to_f >= 5.0 ? false : 'f' }
+      let(:book_id) { books.first.id }
+      let(:true_returning_value) { true }
+      let(:false_returning_value) { false }
 
       it "creates records" do
         assert_difference("Book.count", +1) { result }
@@ -222,21 +214,19 @@ def should_support_postgresql_import_functionality
     end
   end
 
-  if ENV['AR_VERSION'].to_f >= 4.0
-    describe "with a uuid primary key" do
-      let(:vendor) { Vendor.new(name: "foo") }
-      let(:vendors) { [vendor] }
+  describe "with a uuid primary key" do
+    let(:vendor) { Vendor.new(name: "foo") }
+    let(:vendors) { [vendor] }
 
-      it "creates records" do
-        assert_difference "Vendor.count", +1 do
-          Vendor.import vendors
-        end
-      end
-
-      it "assigns an id to the model objects" do
+    it "creates records" do
+      assert_difference "Vendor.count", +1 do
         Vendor.import vendors
-        assert_not_nil vendor.id
       end
+    end
+
+    it "assigns an id to the model objects" do
+      Vendor.import vendors
+      assert_not_nil vendor.id
     end
 
     describe "with an assigned uuid primary key" do
@@ -254,44 +244,38 @@ def should_support_postgresql_import_functionality
   end
 
   describe "with store accessor fields" do
-    if ENV['AR_VERSION'].to_f >= 4.0
-      it "imports values for json fields" do
-        vendors = [Vendor.new(name: 'Vendor 1', size: 100)]
-        assert_difference "Vendor.count", +1 do
-          Vendor.import vendors
-        end
-        assert_equal(100, Vendor.first.size)
+    it "imports values for json fields" do
+      vendors = [Vendor.new(name: 'Vendor 1', size: 100)]
+      assert_difference "Vendor.count", +1 do
+        Vendor.import vendors
       end
-
-      it "imports values for hstore fields" do
-        vendors = [Vendor.new(name: 'Vendor 1', contact: 'John Smith')]
-        assert_difference "Vendor.count", +1 do
-          Vendor.import vendors
-        end
-        assert_equal('John Smith', Vendor.first.contact)
-      end
+      assert_equal(100, Vendor.first.size)
     end
 
-    if ENV['AR_VERSION'].to_f >= 4.2
-      it "imports values for jsonb fields" do
-        vendors = [Vendor.new(name: 'Vendor 1', charge_code: '12345')]
-        assert_difference "Vendor.count", +1 do
-          Vendor.import vendors
-        end
-        assert_equal('12345', Vendor.first.charge_code)
+    it "imports values for hstore fields" do
+      vendors = [Vendor.new(name: 'Vendor 1', contact: 'John Smith')]
+      assert_difference "Vendor.count", +1 do
+        Vendor.import vendors
       end
+      assert_equal('John Smith', Vendor.first.contact)
+    end
+
+    it "imports values for jsonb fields" do
+      vendors = [Vendor.new(name: 'Vendor 1', charge_code: '12345')]
+      assert_difference "Vendor.count", +1 do
+        Vendor.import vendors
+      end
+      assert_equal('12345', Vendor.first.charge_code)
     end
   end
 
-  if ENV['AR_VERSION'].to_f >= 4.2
-    describe "with serializable fields" do
-      it "imports default values as correct data type" do
-        vendors = [Vendor.new(name: 'Vendor 1')]
-        assert_difference "Vendor.count", +1 do
-          Vendor.import vendors
-        end
-        assert_equal({}, Vendor.first.json_data)
+  describe "with serializable fields" do
+    it "imports default values as correct data type" do
+      vendors = [Vendor.new(name: 'Vendor 1')]
+      assert_difference "Vendor.count", +1 do
+        Vendor.import vendors
       end
+      assert_equal({}, Vendor.first.json_data)
     end
 
     %w(json jsonb).each do |json_type|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,14 +21,8 @@ end
 require "active_record"
 require "active_record/fixtures"
 require "active_support/test_case"
-
-if ActiveSupport::VERSION::STRING < "4.0"
-  require 'test/unit'
-  require 'mocha/test_unit'
-else
-  require 'active_support/testing/autorun'
-  require "mocha/minitest"
-end
+require 'active_support/testing/autorun'
+require "mocha/minitest"
 
 require 'timecop'
 require 'chronic'
@@ -38,14 +32,6 @@ begin
 rescue LoadError
   if ENV['AR_VERSION'].to_f <= 7.1
     ENV['SKIP_COMPOSITE_PK'] = 'true'
-  end
-end
-
-# Support MySQL 5.7
-if ActiveSupport::VERSION::STRING < "4.1"
-  require "active_record/connection_adapters/mysql2_adapter"
-  class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-    NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
   end
 end
 
@@ -100,4 +86,4 @@ Dir["#{File.dirname(__FILE__)}/models/*.rb"].sort.each { |file| require file }
 # Prevent this deprecation warning from breaking the tests.
 Rake::FileList.send(:remove_method, :import)
 
-ActiveSupport::TestCase.test_order = :random if ENV['AR_VERSION'].to_f >= 4.2
+ActiveSupport::TestCase.test_order = :random


### PR DESCRIPTION
Removes legacy ActiveRecord version conditions from Gemfile and test files as they are not referenced in the `AR_VERSION` matrix of [`.github/workflows/test.yaml`](https://github.com/zdennis/activerecord-import/blob/9888643430adaf8a1a90d80b953abb0bc9a361a6/.github/workflows/test.yaml). These version-specific code paths are no longer being used in our CI workflow.