### PR TITLE
Remove deprecated ActiveRecord import adapter files

### DIFF
--- a/lib/activerecord-import/mysql2.rb
+++ b/lib/activerecord-import/mysql2.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-warn <<-MSG
-[DEPRECATION] loading activerecord-import via 'require "activerecord-import/<adapter-name>"'
-  is deprecated. Update to autorequire using 'require "activerecord-import"'. See
-  http://github.com/zdennis/activerecord-import/wiki/Requiring for more information
-MSG
-
-require "activerecord-import"

--- a/lib/activerecord-import/postgresql.rb
+++ b/lib/activerecord-import/postgresql.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-warn <<-MSG
-[DEPRECATION] loading activerecord-import via 'require "activerecord-import/<adapter-name>"'
-  is deprecated. Update to autorequire using 'require "activerecord-import"'. See
-  http://github.com/zdennis/activerecord-import/wiki/Requiring for more information
-MSG
-
-require "activerecord-import"

--- a/lib/activerecord-import/sqlite3.rb
+++ b/lib/activerecord-import/sqlite3.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-warn <<-MSG
-[DEPRECATION] loading activerecord-import via 'require "activerecord-import/<adapter-name>"'
-  is deprecated. Update to autorequire using 'require "activerecord-import"'. See
-  http://github.com/zdennis/activerecord-import/wiki/Requiring for more information
-MSG
-
-require "activerecord-import"


### PR DESCRIPTION
Since it's been a considerable amount of time since the warning was added in https://github.com/zdennis/activerecord-import/commit/163f5c64be3f357edfe15a1e393d447938437978, it should be safe to remove it now.
