### PR TITLE
CI against Rails 8.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,8 @@ jobs:
         ruby:
           - 3.3
         env:
+          - AR_VERSION: '8.0'
+            RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: '7.2'
             RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: '7.1'
@@ -46,6 +48,9 @@ jobs:
           - AR_VERSION: 6.1
             RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: 3.2
+            env:
+              AR_VERSION: '8.0'
           - ruby: 3.2
             env:
               AR_VERSION: '7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,13 @@ version = ENV['AR_VERSION'].to_f
 mysql2_version = '0.3.0'
 mysql2_version = '0.4.0' if version >= 4.2
 mysql2_version = '0.5.0' if version >= 6.1
+mysql2_version = '0.5.6' if version >= 8.0
 sqlite3_version = '1.3.0'
 sqlite3_version = '1.4.0' if version >= 6.0
+sqlite3_version = '2.2.0' if version >= 8.0
 pg_version = '0.9'
 pg_version = '1.1' if version >= 6.1
+pg_version = '1.5' if version >= 8.0
 
 group :development, :test do
   gem 'rubocop'

--- a/gemfiles/8.0.gemfile
+++ b/gemfiles/8.0.gemfile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+gem 'activerecord', '~> 8.0.0'

--- a/test/models/author.rb
+++ b/test/models/author.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Author < ActiveRecord::Base
-  if ENV['AR_VERSION'].to_f >= 7.1
+  if ENV['AR_VERSION'].to_f >= 8.0
+    has_many :composite_books, foreign_key: [:id, :author_id], inverse_of: :author
+  elsif ENV['AR_VERSION'].to_f >= 7.1
     has_many :composite_books, query_constraints: [:id, :author_id], inverse_of: :author
   end
 end

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -2,7 +2,7 @@
 
 class Book < ActiveRecord::Base
   belongs_to :topic, inverse_of: :books
-  if ENV['AR_VERSION'].to_f <= 7.0
+  if ENV['AR_VERSION'].to_f <= 7.0 || ENV['AR_VERSION'].to_f >= 8.0
     belongs_to :tag, foreign_key: [:tag_id, :parent_id] unless ENV["SKIP_COMPOSITE_PK"]
   else
     belongs_to :tag, query_constraints: [:tag_id, :parent_id] unless ENV["SKIP_COMPOSITE_PK"]

--- a/test/models/book.rb
+++ b/test/models/book.rb
@@ -10,5 +10,9 @@ class Book < ActiveRecord::Base
   has_many :chapters, inverse_of: :book
   has_many :discounts, as: :discountable
   has_many :end_notes, inverse_of: :book
-  enum status: [:draft, :published] if ENV['AR_VERSION'].to_f >= 4.1
+  if ENV['AR_VERSION'].to_f >= 8.0
+    enum :status, [:draft, :published]
+  elsif ENV['AR_VERSION'].to_f >= 4.1
+    enum status: [:draft, :published]
+  end
 end

--- a/test/models/composite_book.rb
+++ b/test/models/composite_book.rb
@@ -3,7 +3,7 @@
 class CompositeBook < ActiveRecord::Base
   self.primary_key = %i[id author_id]
   belongs_to :author
-  if ENV['AR_VERSION'].to_f <= 7.0
+  if ENV['AR_VERSION'].to_f <= 7.0 || ENV['AR_VERSION'].to_f >= 8.0
     unless ENV["SKIP_COMPOSITE_PK"]
       has_many :composite_chapters, inverse_of: :composite_book,
                                     foreign_key: [:id, :author_id]

--- a/test/models/composite_chapter.rb
+++ b/test/models/composite_chapter.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class CompositeChapter < ActiveRecord::Base
-  if ENV['AR_VERSION'].to_f >= 7.1
+  if ENV['AR_VERSION'].to_f >= 8.0
+    belongs_to :composite_book, inverse_of: :composite_chapters,
+                                foreign_key: [:composite_book_id, :author_id]
+  elsif ENV['AR_VERSION'].to_f >= 7.1
     belongs_to :composite_book, inverse_of: :composite_chapters,
                                 query_constraints: [:composite_book_id, :author_id]
   end

--- a/test/models/customer.rb
+++ b/test/models/customer.rb
@@ -2,7 +2,7 @@
 
 class Customer < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    if ENV['AR_VERSION'].to_f <= 7.0
+    if ENV['AR_VERSION'].to_f <= 7.0 || ENV['AR_VERSION'].to_f >= 8.0
       has_many :orders,
                inverse_of: :customer,
                primary_key: %i(account_id id),

--- a/test/models/order.rb
+++ b/test/models/order.rb
@@ -2,7 +2,7 @@
 
 class Order < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    if ENV['AR_VERSION'].to_f <= 7.0
+    if ENV['AR_VERSION'].to_f <= 7.0 || ENV['AR_VERSION'].to_f >= 8.0
       belongs_to :customer,
                  inverse_of: :orders,
                  primary_key: %i(account_id id),

--- a/test/models/tag_alias.rb
+++ b/test/models/tag_alias.rb
@@ -2,7 +2,7 @@
 
 class TagAlias < ActiveRecord::Base
   unless ENV["SKIP_COMPOSITE_PK"]
-    if ENV['AR_VERSION'].to_f <= 7.0
+    if ENV['AR_VERSION'].to_f <= 7.0 || ENV['AR_VERSION'].to_f >= 8.0
       belongs_to :tag, foreign_key: [:tag_id, :parent_id], required: true
     else
       belongs_to :tag, query_constraints: [:tag_id, :parent_id], required: true


### PR DESCRIPTION
This PR updates our CI configuration to test against Rails 8.0 and addresses two breaking changes:

1. Updates test code to handle the modified `enum` behavior introduced in https://github.com/rails/rails/commit/b9226a68bb18283f9f80e73c4bfa77f2a5309740
2. Replaces `query_constraints` with `foreign_key` to address the exception raising in https://github.com/rails/rails/commit/1a0b4d7dc0fa115e73e32bf0af22d3846b408eeb