### PR TITLE
Add Support for ActiveRecord Proxy Adapters

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,6 +130,7 @@ jobs:
           bundle exec rake test:postgis
           bundle exec rake test:postgresql
           bundle exec rake test:postgresql_makara
+          bundle exec rake test:postgresql_proxy
       - name: Run tests with seamless_database_pool
         run: |
           bundle exec rake test:seamless_database_pool

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,6 +125,7 @@ jobs:
           bundle exec rake test:mysql2
           bundle exec rake test:mysql2_makara
           bundle exec rake test:mysql2spatial
+          bundle exec rake test:mysql2_proxy
       - name: Run tests with postgresql
         run: |
           bundle exec rake test:postgis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Changes in 2.1.0
+
 ### New Features
 
-* Add Support for `active_record_proxy_adapters` gem. Since Rails 7.1 and above the support for 
-  makara is gone. It is no longet maintained. Developers are left struggling. folks over at @nasdaq have written a gem called
-  [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) which
-  does the same thing. Since this gem has its own adapter called `postgresql_proxy` we need to add the same as per the discussions [here.](https://github.com/Nasdaq/active_record_proxy_adapters/issues/20)
+* Add Support for `active_record_proxy_adapters` gem thanks to @stingrayzboy via #\867.
+  Since Rails 7.1 makara no longer works and it is not currently maintained. The @nasdaq team
+  have written a gem called [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters)
+  that implements some makara functionality.
 
 ## Changes in 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changes in 2.1.0
+### New Features
+
+* Add Support for `active_record_proxy_adapters` gem. Since Rails 7.1 and above the support for 
+  makara is gone. It is no longet maintained. Developers are left struggling. folks over at @nasdaq have written a gem called
+  [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) which
+  does the same thing. Since this gem has its own adapter called `postgresql_proxy` we need to add the same as per the discussions [here.](https://github.com/Nasdaq/active_record_proxy_adapters/issues/20)
+
 ## Changes in 2.0.0
 
 ### Breaking Changes

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ ADAPTERS = %w(
   mysql2
   mysql2_makara
   mysql2spatial
+  mysql2_proxy
   jdbcmysql
   jdbcsqlite3
   jdbcpostgresql

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ ADAPTERS = %w(
   jdbcpostgresql
   postgresql
   postgresql_makara
+  postgresql_proxy
   postgis
   makara_postgis
   sqlite3

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -13,6 +13,7 @@ module ActiveRecord::Import
     when 'mysql2spatial' then 'mysql2'
     when 'spatialite' then 'sqlite3'
     when 'postgresql_makara' then 'postgresql'
+    when 'postgresql_proxy' then 'postgresql'
     when 'makara_postgis' then 'postgresql'
     when 'postgis' then 'postgresql'
     when 'cockroachdb' then 'postgresql'

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -11,6 +11,7 @@ module ActiveRecord::Import
     case adapter
     when 'mysql2_makara' then 'mysql2'
     when 'mysql2spatial' then 'mysql2'
+    when 'mysql2_proxy' then 'mysql2'
     when 'spatialite' then 'sqlite3'
     when 'postgresql_makara' then 'postgresql'
     when 'postgresql_proxy' then 'postgresql'

--- a/lib/activerecord-import/version.rb
+++ b/lib/activerecord-import/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module Import
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/test/adapters/mysql2_proxy.rb
+++ b/test/adapters/mysql2_proxy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ENV["ARE_DB"] = "mysql2"

--- a/test/adapters/postgresql_proxy.rb
+++ b/test/adapters/postgresql_proxy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ENV["ARE_DB"] = "postgresql"

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -16,6 +16,9 @@ mysql2spatial:
 mysql2_makara:
   <<: *mysql2
 
+mysql2_proxy:
+  <<: *mysql2
+
 postgresql: &postgresql
   <<: *common
   username: postgres

--- a/test/database.yml.sample
+++ b/test/database.yml.sample
@@ -26,6 +26,9 @@ postgresql: &postgresql
 postresql_makara:
   <<: *postgresql
 
+postresql_proxy:
+  <<: *postgresql
+
 postgis:
   <<: *postgresql
 

--- a/test/github/database.yml
+++ b/test/github/database.yml
@@ -30,6 +30,9 @@ mysql2spatial:
 mysql2_makara:
   <<: *mysql2
 
+mysql2_proxy:
+  <<: *mysql2
+
 oracle:
   <<: *common
   adapter: oracle

--- a/test/github/database.yml
+++ b/test/github/database.yml
@@ -45,6 +45,9 @@ postgresql: &postgresql
 postresql_makara:
   <<: *postgresql
 
+postresql_proxy:
+  <<: *postgresql
+
 postgis:
   <<: *postgresql
 

--- a/test/mysql2_proxy/import_test.rb
+++ b/test/mysql2_proxy/import_test.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require File.expand_path("#{File.dirname(__FILE__)}/../test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/../support/mysql/import_examples")
+
+should_support_mysql_import_functionality

--- a/test/postgresql_proxy/import_test.rb
+++ b/test/postgresql_proxy/import_test.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require File.expand_path("#{File.dirname(__FILE__)}/../test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/../support/postgresql/import_examples")
+
+should_support_postgresql_import_functionality


### PR DESCRIPTION
### New Features

* Add Support for `active_record_proxy_adapters` gem. Since Rails 7.1 and above the support for 
  makara is gone. It is no longet maintained. Developers are left struggling. folks over at @nasdaq have written a gem called
  [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) which
  does the same thing. Since this gem has its own adapter called `postgresql_proxy` we need to add the same as per the discussions [here.](https://github.com/Nasdaq/active_record_proxy_adapters/issues/20)