### PR TITLE
Remove hash content from key mismatch error message

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -1132,8 +1132,6 @@ When importing an array of hashes with provided columns_names, each hash must co
 
 Required keys: #{required_keys}
 Missing keys: #{missing_keys}
-
-Hash: #{hash}
         EOS
       else
         <<-EOS
@@ -1146,8 +1144,6 @@ for the missing keys or group these records into batches by key set before impor
 Required keys: #{required_keys}
 Extra keys: #{extra_keys}
 Missing keys: #{missing_keys}
-
-Hash: #{hash}
         EOS
       end
     end


### PR DESCRIPTION
Fix #868
Test / lint (pull_request) is failing.
Fixed in https://github.com/zdennis/activerecord-import/pull/870