### PR TITLE
ActiveRecord::Base.connection is deprecated, use with_connection instead

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -141,7 +141,7 @@ class ActiveRecord::Associations::CollectionAssociation
     model_klass = reflection.klass
     symbolized_foreign_key = reflection.foreign_key.to_sym
 
-    symbolized_column_names = if model_klass.connection.respond_to?(:supports_virtual_columns?) && model_klass.connection.supports_virtual_columns?
+    symbolized_column_names = if model_klass.connection_pool.with_connection { |conn| conn.respond_to?(:supports_virtual_columns?) && conn.supports_virtual_columns? }
       model_klass.columns.reject(&:virtual?).map { |c| c.name.to_sym }
     else
       model_klass.column_names.map(&:to_sym)

--- a/test/makara_postgis/import_test.rb
+++ b/test/makara_postgis/import_test.rb
@@ -5,6 +5,6 @@ require File.expand_path("#{File.dirname(__FILE__)}/../support/postgresql/import
 
 should_support_postgresql_import_functionality
 
-if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+if ActiveRecord::Base.connection_pool.with_connection(&:supports_on_duplicate_key_update?)
   should_support_postgresql_upsert_functionality
 end

--- a/test/postgis/import_test.rb
+++ b/test/postgis/import_test.rb
@@ -5,6 +5,6 @@ require File.expand_path("#{File.dirname(__FILE__)}/../support/postgresql/import
 
 should_support_postgresql_import_functionality
 
-if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+if ActiveRecord::Base.connection_pool.with_connection(&:supports_on_duplicate_key_update?)
   should_support_postgresql_upsert_functionality
 end

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -2,7 +2,7 @@
 
 def should_support_mysql_import_functionality
   # Forcefully disable strict mode for this session.
-  ActiveRecord::Base.connection.execute "set sql_mode='STRICT_ALL_TABLES'"
+  ActiveRecord::Base.connection_pool.with_connection { |conn| conn.execute "set sql_mode='STRICT_ALL_TABLES'" }
 
   should_support_basic_on_duplicate_key_update
   should_support_on_duplicate_key_ignore

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -3,7 +3,7 @@
 def should_support_postgresql_import_functionality
   should_support_recursive_import
 
-  if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+  if ActiveRecord::Base.connection_pool.with_connection(&:supports_on_duplicate_key_update?)
     should_support_postgresql_upsert_functionality
   end
 
@@ -55,8 +55,8 @@ def should_support_postgresql_import_functionality
 
     describe "with query cache enabled" do
       setup do
-        unless ActiveRecord::Base.connection.query_cache_enabled
-          ActiveRecord::Base.connection.enable_query_cache!
+        unless ActiveRecord::Base.connection_pool.with_connection(&:query_cache_enabled)
+          ActiveRecord::Base.connection_pool.with_connection(&:enable_query_cache!)
           @disable_cache_on_teardown = true
         end
       end
@@ -72,7 +72,7 @@ def should_support_postgresql_import_functionality
 
       teardown do
         if @disable_cache_on_teardown
-          ActiveRecord::Base.connection.disable_query_cache!
+          ActiveRecord::Base.connection_pool.with_connection(&:disable_query_cache!)
         end
       end
     end

--- a/test/support/shared_examples/recursive_import.rb
+++ b/test/support/shared_examples/recursive_import.rb
@@ -198,7 +198,7 @@ def should_support_recursive_import
 
     # If adapter supports on_duplicate_key_update and specific columns are specified, it is only applied to top level models so that SQL with invalid
     # columns, keys, etc isn't generated for child associations when doing recursive import
-    if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+    if ActiveRecord::Base.connection_pool.with_connection(&:supports_on_duplicate_key_update?)
       describe "on_duplicate_key_update" do
         let(:new_topics) { Build(1, :topic_with_book) }
 

--- a/test/support/sqlite3/import_examples.rb
+++ b/test/support/sqlite3/import_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def should_support_sqlite3_import_functionality
-  if ActiveRecord::Base.connection.supports_on_duplicate_key_update?
+  if ActiveRecord::Base.connection_pool.with_connection(&:supports_on_duplicate_key_update?)
     should_support_sqlite_upsert_functionality
   end
 

--- a/test/synchronize_test.rb
+++ b/test/synchronize_test.rb
@@ -8,9 +8,11 @@ describe ".synchronize" do
 
   setup do
     # update records outside of ActiveRecord knowing about it
-    Topic.connection.execute( "UPDATE #{Topic.table_name} SET title='#{titles[0]}_haha' WHERE id=#{topics[0].id}", "Updating record 1 without ActiveRecord" )
-    Topic.connection.execute( "UPDATE #{Topic.table_name} SET title='#{titles[1]}_haha' WHERE id=#{topics[1].id}", "Updating record 2 without ActiveRecord" )
-    Topic.connection.execute( "UPDATE #{Topic.table_name} SET title='#{titles[2]}_haha' WHERE id=#{topics[2].id}", "Updating record 3 without ActiveRecord" )
+    Topic.connection_pool.with_connection do |conn|
+      conn.execute( "UPDATE #{Topic.table_name} SET title='#{titles[0]}_haha' WHERE id=#{topics[0].id}", "Updating record 1 without ActiveRecord" )
+      conn.execute( "UPDATE #{Topic.table_name} SET title='#{titles[1]}_haha' WHERE id=#{topics[1].id}", "Updating record 2 without ActiveRecord" )
+      conn.execute( "UPDATE #{Topic.table_name} SET title='#{titles[2]}_haha' WHERE id=#{topics[2].id}", "Updating record 3 without ActiveRecord" )
+    end
   end
 
   it "reloads data for the specified records" do
@@ -35,7 +37,7 @@ describe ".synchronize" do
 
   it "ignores default scope" do
     # update records outside of ActiveRecord knowing about it
-    Topic.connection.execute( "UPDATE #{Topic.table_name} SET approved='0' WHERE id=#{topics[0].id}", "Updating record 1 without ActiveRecord" )
+    Topic.connection_pool.with_connection { |conn| conn.execute( "UPDATE #{Topic.table_name} SET approved='0' WHERE id=#{topics[0].id}", "Updating record 1 without ActiveRecord" ) }
 
     Topic.synchronize topics
     assert_equal false, topics[0].approved


### PR DESCRIPTION
`ActiveRecord::Base.connection` was deprecated in v7.2, explicitly get a connection with `with_connection` instead.