### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.3
+          - 3.4
         env:
           - AR_VERSION: '8.0'
             RUBYOPT: --enable-frozen-string-literal
@@ -45,9 +45,24 @@ jobs:
             RUBYOPT: --enable-frozen-string-literal
           - AR_VERSION: '7.0'
             RUBYOPT: --enable-frozen-string-literal
-          - AR_VERSION: 6.1
+          - AR_VERSION: '6.1'
             RUBYOPT: --enable-frozen-string-literal
         include:
+          - ruby: 3.3
+            env:
+              AR_VERSION: '8.0'
+          - ruby: 3.3
+            env:
+              AR_VERSION: '7.2'
+          - ruby: 3.3
+            env:
+              AR_VERSION: '7.1'
+          - ruby: 3.3
+            env:
+              AR_VERSION: '7.0'
+          - ruby: 3.3
+            env:
+              AR_VERSION: '6.1'
           - ruby: 3.2
             env:
               AR_VERSION: '8.0'

--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,14 @@ end
 
 gem "minitest"
 
+# mutex_m, drb, base64, bigdecimal moved from default gems to bundled gems in Ruby 3.4.0.
+# ActiveSupport 6.1-7.0 don't include these gems as dependencies, so they must be explicitly required.
+# ActiveSupport 7.1+ includes them as dependencies or not required, so no explicit inclusion is needed.
+if version >= 6.1 && version <= 7.0 && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+  gem "mutex_m"
+  gem "drb"
+  gem "base64"
+  gem "bigdecimal"
+end
+
 eval_gemfile File.expand_path("../gemfiles/#{version}.gemfile", __FILE__)


### PR DESCRIPTION
This PR adds Ruby 3.4 support to the CI matrix. It includes conditional dependencies (`mutex_m`, `drb`, `base64`, `bigdecimal`) required for ActiveSupport 6.1-7.0 compatibility with Ruby 3.4, as these gems were moved from default to bundled gems.