### PR TITLE
Fix ActiveRecordProxyAdapters support

### DIFF
--- a/lib/activerecord-import/active_record/adapters/mysql2_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/mysql2_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/mysql2_proxy_adapter"
+require "activerecord-import/adapters/mysql2_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_mysql2proxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::Mysql2ProxyAdapter)
+end

--- a/lib/activerecord-import/active_record/adapters/postgresql_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/postgresql_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/postgresql_proxy_adapter"
+require "activerecord-import/adapters/postgresql_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_postgresqlproxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::PostgreSQLProxyAdapter)
+end

--- a/lib/activerecord-import/adapters/active_record_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/active_record_proxy_adapter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveRecord::Import::ActiveRecordProxyAdapter
+  def insert_many(*args, **kwargs, &block)
+    sticking_to_primary { super(*args, **kwargs, &block) }
+  end
+
+  def insert(*args, **kwargs, &block)
+    sticking_to_primary { super(*args, **kwargs, &block) }
+  end
+
+  def sticking_to_primary(&block)
+    ActiveRecord::Base.connected_to(role: writing_role, &block)
+  end
+
+  def writing_role
+    ActiveRecord.try(:writing_role) || ActiveRecord::Base.try(:writing_role) || :writing
+  end
+end

--- a/lib/activerecord-import/adapters/mysql2_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql2_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/mysql2_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::Mysql2ProxyAdapter
+  include ActiveRecord::Import::Mysql2Adapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end

--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -93,7 +93,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
       sql << " RETURNING #{selections.join(', ')}"
     end
 
-    sql
+    sql.uniq
   end
 
   def returning_selections(options)

--- a/lib/activerecord-import/adapters/postgresql_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/postgresql_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::PostgreSQLProxyAdapter
+  include ActiveRecord::Import::PostgreSQLAdapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end

--- a/lib/activerecord-import/base.rb
+++ b/lib/activerecord-import/base.rb
@@ -11,11 +11,11 @@ module ActiveRecord::Import
     case adapter
     when 'mysql2_makara' then 'mysql2'
     when 'mysql2spatial' then 'mysql2'
-    when 'mysql2_proxy' then 'mysql2'
+    when 'mysql2_proxy' then 'mysql2_proxy'
     when 'janus_mysql2' then 'mysql2'
     when 'spatialite' then 'sqlite3'
     when 'postgresql_makara' then 'postgresql'
-    when 'postgresql_proxy' then 'postgresql'
+    when 'postgresql_proxy' then'postgresql_proxy'
     when 'makara_postgis' then 'postgresql'
     when 'postgis' then 'postgresql'
     when 'cockroachdb' then 'postgresql'


### PR DESCRIPTION
Hi there! I'm the maintainer of `active_record_proxy_adapters`.

`ActiveRecordProxyAdapters` works on the premise that an incoming SQL string could be either a read or a write and has some routing mechanism in place to decide which database it should send the request too. That uses `Regexp` pattern matching which, in most cases, should perform pretty quickly but in the context of this gem, it might be a bottleneck depending on how long the query string is - since it's meant for bulk imports.

Because we know for a fact that the imports are always going to be writes, it is safe to bypass most of the routing logic by wrapping the calls within a `connected_to` block (introduced in Rails 6). This reduces the pattern matching overhead which would happen for every bulk import and allows the queries to go straight to the writer instance.

I decided to make this change after a bug was reported which was also impacting activerecord-import users: https://github.com/Nasdaq/active_record_proxy_adapters/issues/113

Thanks!

