### PR TITLE
Add affected rows support for MySQL adapter

### DIFF
--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -12,6 +12,7 @@ module ActiveRecord::Import::MysqlAdapter
   def insert_many( sql, values, options = {}, *args ) # :nodoc:
     # the number of inserts default
     number_of_inserts = 0
+    affected_rows = raw_connection.respond_to?(:affected_rows) ? 0 : nil
 
     base_sql, post_sql = case sql
                          when String
@@ -37,7 +38,8 @@ module ActiveRecord::Import::MysqlAdapter
     if max == NO_MAX_PACKET || total_bytes <= max || options[:force_single_insert]
       number_of_inserts += 1
       sql2insert = base_sql + values.join( ',' ) + post_sql
-      insert( sql2insert, *args )
+      execute( sql2insert, *args )
+      affected_rows += raw_connection.affected_rows if affected_rows
     else
       value_sets = ::ActiveRecord::Import::ValueSetsBytesParser.parse(values,
         reserved_bytes: sql_size,
@@ -47,12 +49,13 @@ module ActiveRecord::Import::MysqlAdapter
         value_sets.each do |value_set|
           number_of_inserts += 1
           sql2insert = base_sql + value_set.join( ',' ) + post_sql
-          insert( sql2insert, *args )
+          execute( sql2insert, *args )
+          affected_rows += raw_connection.affected_rows if affected_rows
         end
       end
     end
 
-    ActiveRecord::Import::Result.new([], number_of_inserts, [], [])
+    ActiveRecord::Import::Result.new([], number_of_inserts, [], [], affected_rows)
   end
 
   # Returns the maximum number of bytes that the server will allow

--- a/test/support/mysql/import_examples.rb
+++ b/test/support/mysql/import_examples.rb
@@ -6,6 +6,7 @@ def should_support_mysql_import_functionality
 
   should_support_basic_on_duplicate_key_update
   should_support_on_duplicate_key_ignore
+  should_support_affected_rows
 
   describe "#import" do
     context "with :on_duplicate_key_update and validation checks turned off" do

--- a/test/support/shared_examples/affected_rows.rb
+++ b/test/support/shared_examples/affected_rows.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+def should_support_affected_rows
+  describe "#import" do
+    extend ActiveSupport::TestCase::ImportAssertions
+
+    context "with affected_rows tracking" do
+      it "should return correct affected_rows count for basic import" do
+        topics = Build(2, :topics)
+
+        initial_count = Topic.count
+        result = Topic.import topics, validate: false
+        final_count = Topic.count
+        actual_inserted = final_count - initial_count
+
+        skip "affected_rows not supported on this adapter" if result.affected_rows.nil?
+
+        assert_equal actual_inserted, result.affected_rows, "affected_rows should match actual database inserts"
+      end
+
+      it "should return correct affected_rows count with on_duplicate_key_ignore" do
+        existing = Build(:topic)
+        existing.save!
+
+        topics = [
+          Build(:topic, id: existing.id),  # This should be ignored
+          Build(:topic)                    # This should be inserted
+        ]
+
+        initial_count = Topic.count
+        result = Topic.import topics, on_duplicate_key_ignore: true, validate: false
+        final_count = Topic.count
+        actual_inserted = final_count - initial_count
+
+        assert_equal 1, actual_inserted, "Database should show 1 new record (duplicate ignored)"
+
+        skip "affected_rows not supported on this adapter" if result.affected_rows.nil?
+
+        assert_equal actual_inserted, result.affected_rows, "affected_rows should match actual database inserts"
+        assert_equal 1, result.num_inserts, "num_inserts should be 1 (single INSERT statement)"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Add `affected_rows` tracking to import results

## Problem

When using `on_duplicate_key_ignore`, `num_inserts` only shows SQL statements executed, not actual rows inserted.

```ruby
# Current limitation
result = Model.import(500_records, on_duplicate_key_ignore: true)
puts result.num_inserts    # => 1 (one INSERT statement)
puts "Actual inserts: ?"  # => No way to know how many were duplicates!
```

## Solution

Add `affected_rows` field to track actual database insertions:

```ruby
result = Model.import(records, on_duplicate_key_ignore: true)
puts result.num_inserts     # => 1 (SQL statements)
puts result.affected_rows   # => 347 (actual rows inserted) or nil (not supported)
puts "Duplicates: #{records.size - result.affected_rows}" if result.affected_rows
```

## Implementation

**Result struct** (`lib/activerecord-import/import.rb`):
```ruby
Result = Struct.new(:failed_instances, :num_inserts, :ids, :results, :affected_rows)
```

**MySQL adapter** (`lib/activerecord-import/adapters/mysql_adapter.rb`):
```ruby
# Check support once at initialization
affected_rows = raw_connection.respond_to?(:affected_rows) ? 0 : nil

# Only accumulate when supported
execute(sql2insert, *args)
affected_rows += raw_connection.affected_rows if affected_rows
```

**Key technical changes:**
- **Honest API**: Returns `nil` when `affected_rows` is not supported instead of misleading `0`
- **Support detection**: Checks `raw_connection.respond_to?(:affected_rows)` to determine capability
- **Direct access**: Uses MySQL's native `affected_rows()` function for accuracy

## Why This Matters

**Data Pipeline Monitoring:**
```ruby
result = User.import(batch, on_duplicate_key_ignore: true)
if result.affected_rows
  duplicate_rate = 1 - (result.affected_rows.to_f / batch.size)
  alert_if_too_many_duplicates(duplicate_rate)
else
  logger.warn "affected_rows not supported on this adapter"
end
```

**Performance Optimization:**
```ruby
# Find optimal batch size based on actual throughput
result = Model.import(records, batch_size: 1000)
throughput = result.affected_rows ? result.affected_rows / duration : nil
```

## Backward Compatibility

- ✅ Fully backward compatible
- ✅ `affected_rows` returns `nil` for unsupported adapters
- ✅ MySQL implementation to keep a small PR. This can be extended to other databases.

## Platform Support

**✅ Supported:**
- Ruby + MySQL2 adapter: Full `affected_rows` functionality

**⚠️ Known Limitations:**  
- This was not tested with **JRuby + JDBC MySQL**
- This doesn't affect core import functionality - only the new metrics feature

## Testing

Added comprehensive test coverage in `test/support/shared_examples/affected_rows.rb` with smart adapter detection:
- Tests run normally on supported adapters (MySQL2)
- Tests skip gracefully on unsupported adapters (JDBC) with clear messaging
- Dynamic detection based on actual `result.affected_rows` value rather than platform detection
