### PR TITLE
Fix affected_rows data source for ON DUPLICATE KEY UPDATE operations

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -837,7 +837,7 @@ class ActiveRecord::Base
       number_inserted = 0
       ids = []
       results = []
-      affected_rows = nil
+      affected_rows = 0
 
       if supports_import?(conn)
         # generate the sql
@@ -862,7 +862,7 @@ class ActiveRecord::Base
           number_inserted += result.num_inserts
           ids += result.ids
           results += result.results
-          affected_rows = result.affected_rows
+          affected_rows = result.affected_rows.nil? ? nil : (affected_rows || 0) + result.affected_rows
           current_batch += 1
 
           progress_proc.call(import_size, batches, current_batch, Time.now.to_i - batch_started_at) if run_proc

--- a/test/support/shared_examples/affected_rows.rb
+++ b/test/support/shared_examples/affected_rows.rb
@@ -39,6 +39,25 @@ def should_support_affected_rows
         assert_equal actual_inserted, result.affected_rows, "affected_rows should match actual database inserts"
         assert_equal 1, result.num_inserts, "num_inserts should be 1 (single INSERT statement)"
       end
+
+      it "should return correct affected_rows count with on_duplicate_key_update" do
+        existing = Build(:topic)
+        existing.save!
+
+        # Create a duplicate with different data to trigger UPDATE
+        topics = [
+          Build(:topic, id: existing.id, title: "Updated Title") # This should update
+        ]
+
+        result = Topic.import topics,
+          on_duplicate_key_update: [:title],
+          validate: false
+
+        skip "affected_rows not supported on this adapter" if result.affected_rows.nil?
+
+        # MySQL returns 2 for ON DUPLICATE KEY UPDATE when a row is actually updated
+        assert_equal 2, result.affected_rows, "affected_rows should be 2 for ON DUPLICATE KEY UPDATE"
+      end
     end
   end
 end


### PR DESCRIPTION
Problem: `affected_rows` always returned `0` for `ON DUPLICATE KEY UPDATE` operations in Trilogy adapter.

Root Cause: In this [PR](https://github.com/zdennis/activerecord-import/pull/882), we had used `raw_connection.affected_rows` which returns stale/incorrect values for ON DUPLICATE KEY UPDATE in Trilogy.

The correct values are available in `result.affected_rows` from the execute result object, so this simply changes the implementation to make use of the result rather than the connection to fetch the `affected_rows`, super simple change.


This PR:
Switch from `raw_connection.affected_rows` to `result.affected_rows` when available
Preserve `nil` for adapters without support
Adds a test to cover for that edge case
Fix batch accumulation to handle nil values properly
