### PR TITLE
Move lazy loading from Base to ConnectionAdapters::ConnectionHandler

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -251,18 +251,20 @@ class ActiveRecord::Associations::CollectionAssociation
   alias import bulk_import unless respond_to? :import
 end
 
-module ActiveRecord::Import::Connection
-  def establish_connection(args = nil)
-    conn = super(args)
-    ActiveRecord::Import.load_from_connection_pool connection_pool
-    conn
+module ActiveRecord::Import::ConnectionHandler
+  def establish_connection(*args, **kwargs, &block)
+    pool = super(*args, **kwargs, &block)
+    ActiveRecord::Import.load_from_connection_pool pool
+    pool
   end
+end
+
+class ActiveRecord::ConnectionAdapters::ConnectionHandler
+  prepend ActiveRecord::Import::ConnectionHandler
 end
 
 class ActiveRecord::Base
   class << self
-    prepend ActiveRecord::Import::Connection
-
     # Returns true if the current database connection adapter
     # supports import functionality, otherwise returns false.
     def supports_import?(conn = nil)


### PR DESCRIPTION
Follow-up from the discussion in #880.

There's an issue when using activerecord-import in non-Rails applications. It works as expected on Rails applications because of the Railtie magic:

1. `ActiveRecord::Base.establish_connection` calls `ActiveRecord::ConnectionAdapters::ConnectionHandler#establish_connection` under the hood
2. `activerecord-impact` overrides `ActiveRecord::Base.establish_connection` (this is where the specific adapter file is required for the bulk import. Without it, we get n queries instead of just 1)
3. `ActiveRecord::Railtie` calls `ActiveRecord::Base.establish_connection`, which will now call the overridden method and load the specific adapter

Now if you use this gem off Rails, (i.e. you only have `activerecord` in your Gemfile), you will still need to establish the connection at some point. That, however, can be done in two different ways (both are valid and officially supported):

1. Calling `ActiveRecord::Base.establish_connection` or,
2. Calling `ActiveRecord::Base::ConnectionAdapters::ConnectionHandler#establish_connection`. *This one* is called automatically by ActiveRecord when trying to run queries against a model for which a connection hasn't been established yet.

For simple applications where all models will have the same parent class, it makes sense to use option 1. For applications where you might not want to hold a connection to a specific database until needed (lazy connections), you might use option 2 instead.

Since, for this gem, it doesn't really matter which of the two is called anyways, as we're just using it to lazily load the bulk import adapter for the connection, I think it makes sense to move that patch to `ConnectionHandler` instead, as that will cover all cases because:

1. It will always be called regardless of which option was used, meaning the bulk import dependency is guaranteed to be loaded
2. It will mean this gem will work on and off Rails (and I think it should since `rails` is not a gem dependency, only `activerecord`)