### PR TITLE
add proxy adapters to 1.8.0

### DIFF
--- a/lib/activerecord-import/active_record/adapters/mysql2_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/mysql2_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/mysql2_proxy_adapter"
+require "activerecord-import/adapters/mysql2_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_mysql2proxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::Mysql2ProxyAdapter)
+end

--- a/lib/activerecord-import/active_record/adapters/postgresql_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/postgresql_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/postgresql_proxy_adapter"
+require "activerecord-import/adapters/postgresql_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_postgresqlproxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::PostgreSQLProxyAdapter)
+end

--- a/lib/activerecord-import/active_record/adapters/sqlite3_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/sqlite3_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/sqlite3_proxy_adapter"
+require "activerecord-import/adapters/sqlite3_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_sqlite3proxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::SQLite3ProxyAdapter)
+end

--- a/lib/activerecord-import/active_record/adapters/trilogy_proxy_adapter.rb
+++ b/lib/activerecord-import/active_record/adapters/trilogy_proxy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/trilogy_proxy_adapter"
+require "activerecord-import/adapters/trilogy_proxy_adapter"
+
+ActiveSupport.on_load(:active_record_trilogyproxyadapter) do |klass|
+  klass.include(ActiveRecord::Import::TrilogyProxyAdapter)
+end

--- a/lib/activerecord-import/adapters/active_record_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/active_record_proxy_adapter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveRecord::Import::ActiveRecordProxyAdapter
+  def insert_many(*args, **kwargs, &block)
+    sticking_to_primary { super(*args, **kwargs, &block) }
+  end
+
+  def insert(*args, **kwargs, &block)
+    sticking_to_primary { super(*args, **kwargs, &block) }
+  end
+
+  def sticking_to_primary(&block)
+    ActiveRecord::Base.connected_to(role: writing_role, &block)
+  end
+
+  def writing_role
+    ActiveRecord.try(:writing_role) || ActiveRecord::Base.try(:writing_role) || :writing
+  end
+end

--- a/lib/activerecord-import/adapters/mysql2_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql2_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/mysql2_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::Mysql2ProxyAdapter
+  include ActiveRecord::Import::Mysql2Adapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end

--- a/lib/activerecord-import/adapters/postgresql_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/postgresql_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::PostgreSQLProxyAdapter
+  include ActiveRecord::Import::PostgreSQLAdapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end

--- a/lib/activerecord-import/adapters/sqlite3_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/sqlite3_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::SQLite3ProxyAdapter
+  include ActiveRecord::Import::SQLite3Adapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end

--- a/lib/activerecord-import/adapters/trilogy_proxy_adapter.rb
+++ b/lib/activerecord-import/adapters/trilogy_proxy_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "activerecord-import/adapters/trilogy_adapter"
+require "activerecord-import/adapters/active_record_proxy_adapter"
+
+module ActiveRecord::Import::TrilogyProxyAdapter
+  include ActiveRecord::Import::TrilogyAdapter
+  include ActiveRecord::Import::ActiveRecordProxyAdapter
+end


### PR DESCRIPTION
this pr backports @mateuscruz changes onto version 1.8.0 to make this version compatible with the `active_record_proxy_adapters` gem