### PR TITLE
Move column_names assignment inside returning_selections

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -98,12 +98,12 @@ module ActiveRecord::Import::PostgreSQLAdapter
 
   def returning_selections(options)
     selections = []
-    column_names = Array(options[:model].column_names)
 
     selections += Array(options[:primary_key]) if options[:primary_key].present?
     selections += Array(options[:returning]) if options[:returning].present?
 
     selections.map do |selection|
+      column_names = Array(options[:model].column_names)
       column_names.include?(selection.to_s) ? "\"#{selection}\"" : selection
     end
   end


### PR DESCRIPTION
When running the import, I was getting error from deep inside this gem:
```
undefined method 'column_names' for nil (NoMethodError)
```

Something is probably wrong on more layers, but the fix on this place is **simple** and **safe**, because `column_names` are not needed if there are no `selections`.