### PR TITLE
Fix docker-compose: make local stack bootable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,19 @@ services:
       - mysql-data:/var/lib/mysql
     ports:
       - "3306:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_DATABASE: activerecord_import_test
 
   postgresql:
-    image: postgres:latest
+    image: postgis/postgis:10-2.5
     volumes:
       - postgresql-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: activerecord_import_test
 
   app:
     build:


### PR DESCRIPTION
## Summary
- On `master`, `docker compose up` fails out of the box: both MySQL and PostgreSQL containers exit immediately because no password / auth env vars are configured.
- Bump the PostgreSQL image from `postgres:latest` to `postgis/postgis:10-2.5` so the local stack matches the version used in [CI](https://github.com/zdennis/activerecord-import/blob/d3d3f8a130ed8c31b6ea487a18f264b3a9288dd3/.github/workflows/test.yaml#L7).
- Auto-create the `activerecord_import_test` database on first boot for both MySQL and PostgreSQL via the standard image env vars, so contributors don't have to `psql` / `mysql` into the containers manually.

## Why
Currently `docker-compose up --build` does not work:
```
postgresql-1  | Error: Database is uninitialized and superuser password is not specified.
postgresql-1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgresql-1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgresql-1  | 
postgresql-1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgresql-1  |        connections without a password. This is *not* recommended.
postgresql-1  | 
postgresql-1  |        See PostgreSQL documentation about "trust":
postgresql-1  |        https://www.postgresql.org/docs/current/auth-trust.html
mysql-1       | 2026-04-26 14:54:33+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.44-1.el7 started.
postgresql-1 exited with code 1
mysql-1       | 2026-04-26 14:54:34+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
mysql-1       | 2026-04-26 14:54:34+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.44-1.el7 started.
mysql-1       | 2026-04-26 14:54:35+00:00 [ERROR] [Entrypoint]: Database is uninitialized and password option is not specified
mysql-1       |     You need to specify one of the following as an environment variable:
mysql-1       |     - MYSQL_ROOT_PASSWORD
mysql-1       |     - MYSQL_ALLOW_EMPTY_PASSWORD
mysql-1       |     - MYSQL_RANDOM_ROOT_PASSWORD
mysql-1 exited with code 1
```

## Test

```
docker-compose down -v # for clean up
docker-compose up --build
docker-compose exec app bundle exec rake test:postgresql test:sqlite3 test:mysql2
```