### PR TITLE
Fix failing CI caused by minitest/rails_plugin LoadError

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ end
 require "active_record"
 require "active_record/fixtures"
 require "active_support/test_case"
-require 'active_support/testing/autorun'
+require 'minitest/autorun'
 require "mocha/minitest"
 
 require 'timecop'


### PR DESCRIPTION
## Summary
Replace `require 'active_support/testing/autorun'` with `require 'minitest/autorun'`  to unblock CI.

## Background
CI started failing with the following LoadError when [running the test](https://github.com/zdennis/activerecord-import/actions/runs/24959836912/job/73084461577):
```
cannot load such file -- minitest/rails_plugin (LoadError)
    from .../minitest-6.0.5/lib/minitest.rb:104:in `block in load'
    from .../activesupport-8.0.5/lib/active_support/testing/autorun.rb:9:in `<top (required)>'
    from .../test/test_helper.rb:26:in `<top (required)>'
```
## Root cause
The trigger is this line in active_support/testing/autorun.rb ([rails/rails@3d7458f](https://github.com/rails/rails/blob/3d7458fecf4943a92cbf8c33e83bb959109a103f/activesupport/lib/active_support/testing/autorun.rb#L9)):

In Minitest 6, `Minitest.load(:rails)` tries to require 'minitest/rails_plugin', which lives in the [railties gem](https://github.com/rails/rails/blob/3d7458fecf4943a92cbf8c33e83bb959109a103f/railties/lib/minitest/rails_plugin.rb). activerecord-import depends on activesupport but not railties, so the require fails with LoadError and aborts the test run before any test executes.

## Solution
By switching to `minitest/autorun`, we bypass the Rails-specific plugin loading while still allowing the tests to run. 