### PR TITLE
chore: upgrade MySQL image from 5.7 to 8.0 in CI and docker-compose

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
         env:
           MYSQL_HOST: 127.0.0.1
           MYSQL_ROOT_PASSWORD: root
+          MYSQL_ROOT_HOST: '%'
           MYSQL_USER: github
           MYSQL_PASSWORD: github
           MYSQL_DATABASE: activerecord_import_test
@@ -133,6 +134,12 @@ jobs:
           rubygems: latest
       - name: Set up databases
         run: |
+          sudo apt-get update
+          sudo apt-get install -y default-mysql-client
+          mysql -h 127.0.0.1 -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+          mysql -h 127.0.0.1 -uroot -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
+          mysql -h 127.0.0.1 -uroot -proot -e "ALTER USER 'github'@'%' IDENTIFIED WITH mysql_native_password BY 'github';"
+          mysql -h 127.0.0.1 -uroot -proot -e "FLUSH PRIVILEGES;"
           psql -h localhost -U postgres -c 'create database ${{ env.DB_DATABASE }};'
           psql -h localhost -U postgres -d ${{ env.DB_DATABASE }} -c 'create extension if not exists hstore;'
           psql -h localhost -U postgres -c 'create extension if not exists postgis;'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         ports:
           - 3306:3306
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   mysql:
     platform: linux/x86_64
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql-data:/var/lib/mysql
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   mysql:
     platform: linux/x86_64
     image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
     volumes:
       - mysql-data:/var/lib/mysql
     ports:


### PR DESCRIPTION
## Summary

- Upgrade the MySQL Docker image from `5.7` to `8.0` in GitHub Actions CI and `docker-compose.yml`
- MySQL 5.7 reached end of life in October 2023; this aligns the test environment with versions commonly used in production

## Motivation

The project has been testing against MySQL 5.7 since the Travis CI era. There does not appear to be a prior issue or PR specifically proposing this upgrade. Updating to MySQL 8.0 keeps CI closer to real-world deployments without changing any application code.

## Test plan

- [x] Local Docker: `docker-compose up --build` → `bundle exec rake test:mysql2` (205 runs, 440 assertions, 0 failures, 0 errors)
- [x] GitHub Actions CI passes