### PR TITLE
Document #886's fix in CHANGELOG (Unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 * Add Support for trilogy_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz
 * Add Support for sqlite3_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz
+* Fix adapter-specific import support (e.g. `on_duplicate_key_update`) never loading for
+  a connection established via `connects_to`/`ActiveRecord::ConnectionAdapters::
+  ConnectionHandler#establish_connection` instead of `ActiveRecord::Base.establish_connection`
+  directly - most commonly hit with a Rails multi-database secondary connection. The lazy
+  adapter loader now hooks `ConnectionHandler#establish_connection` instead of
+  `ActiveRecord::Base.establish_connection`, so it fires for every connection regardless of
+  how it was established. Thanks to @mateuscruz via #886.
 
 ## Changes in 2.2.0
 


### PR DESCRIPTION
## Summary

While debugging why `activerecord-import`'s adapter-specific support (e.g. `on_duplicate_key_update`) wasn't loading for a secondary MySQL connection set up via `connects_to` in a Rails 8 multi-database app, I traced it to exactly what #886 already fixed - moving the lazy adapter-loading hook from `ActiveRecord::Base.establish_connection` (only ever called for the primary connection at boot) to `ActiveRecord::ConnectionAdapters::ConnectionHandler#establish_connection` (fires for every connection, regardless of how it was established).

That fix is merged to `master` but isn't mentioned in the `Unreleased` section of CHANGELOG.md yet - this PR just adds that entry, so it's visible ahead of the next release.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)