### PR TITLE
Rename variable name in README sample code to align with naming convention

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -121,20 +121,20 @@ Book.import values
 The `import` method can take an array of column names and an array of hash objects. The column names are used to determine what fields of data should be imported. The following example will only import books with the `title` field:
 
 ```ruby
-books = [
+values = [
   { title: "Book 1", author: "George Orwell" },
   { title: "Book 2", author: "Bob Jones" }
 ]
 columns = [ :title ]
 
 # without validations
-Book.import columns, books, validate: false
+Book.import columns, values, validate: false
 
 # with validations
-Book.import columns, books, validate: true
+Book.import columns, values, validate: true
 
 # when not specified :validate defaults to true
-Book.import columns, books
+Book.import columns, values
 
 # result in table books
 # title  | author


### PR DESCRIPTION
## Summary

Rename the variable `books` to `values` in the `Import Using Hashes and Explicit Column Names` sample code in the README.

## Motivation

The rest of the README follows a consistent naming convention:

- `values`: for primitive values (Hash or Array)
- `books` : for `Book` object instances

The `Import Using Hashes and Explicit Column Names` section uses Hash values but names the variable `books`, inconsistent with this convention.
