### PR TITLE
Fix NoMethodError on Rails main by no longer requiring ActiveModel's private validation_context= writer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,12 @@ jobs:
           - AR_VERSION: '6.1'
             RUBYOPT: --enable-frozen-string-literal
         include:
+          # Rails main (8.2.0.alpha). Allowed to fail so that in-flight upstream changes do
+          # not turn the whole matrix red; see continue-on-error below.
+          - ruby: 3.4
+            experimental: true
+            env:
+              AR_VERSION: '8.2'
           - ruby: 3.3
             env:
               AR_VERSION: '8.1'
@@ -118,6 +124,7 @@ jobs:
             env:
               AR_VERSION: 5.2
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     env:
       AR_VERSION: ${{ matrix.env.AR_VERSION }}
       DB_DATABASE: activerecord_import_test
@@ -130,7 +137,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          # Skip the cache for the Rails main target; a cached Gemfile.lock would pin the
+          # git source to a stale revision instead of resolving the current branch head.
+          bundler-cache: ${{ !matrix.experimental }}
           rubygems: latest
       - name: Set up databases
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -137,10 +137,13 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          # Skip the cache for the Rails main target; a cached Gemfile.lock would pin the
-          # git source to a stale revision instead of resolving the current branch head.
-          bundler-cache: ${{ !matrix.experimental }}
+          bundler-cache: true
           rubygems: latest
+      - name: Update Rails to the current main revision
+        # A restored bundler cache can pin the git source to a stale revision, which would
+        # quietly test an old Rails main instead of the current branch head.
+        if: ${{ matrix.experimental }}
+        run: bundle update activesupport activemodel activerecord
       - name: Set up databases
         run: |
           sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* Fix `NoMethodError: undefined method 'validation_context='` when importing with validations
+  against Rails main (8.2.0.alpha). Rails removed ActiveModel's private `validation_context=`
+  writer in rails/rails@0f9d1270834a6407a59637650bf910d8ae826169 in favor of a validation
+  context object reachable through `context_for_validation`. `ActiveRecord::Import::Validator`
+  now sets and restores the validation context through whichever API the loaded ActiveModel
+  provides.
+
 * Add Support for trilogy_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz
 * Add Support for sqlite3_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz
 * Fix adapter-specific import support (e.g. `on_duplicate_key_update`) never loading for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   writer in rails/rails@0f9d1270834a6407a59637650bf910d8ae826169 in favor of a validation
   context object reachable through `context_for_validation`. `ActiveRecord::Import::Validator`
   now sets and restores the validation context through whichever API the loaded ActiveModel
-  provides.
+  provides. Thanks to @yu-yaba via #900.
 
 * Add Support for trilogy_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz
 * Add Support for sqlite3_proxy from [active_record_proxy_adapters](https://rubygems.org/gems/active_record_proxy_adapters) by @mateuscruz

--- a/gemfiles/8.2.gemfile
+++ b/gemfiles/8.2.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# 8.2 is the version currently under development on the Rails main branch. Tracking the
+# branch itself (rather than a released gem) is what surfaces upstream removals such as
+# ActiveModel's private #validation_context= writer before they reach a stable release.
+git 'https://github.com/rails/rails.git', branch: 'main' do
+  gem 'activesupport'
+  gem 'activemodel'
+  gem 'activerecord'
+end

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -79,7 +79,7 @@ module ActiveRecord::Import # :nodoc:
       current_context = model.send(:validation_context)
 
       begin
-        model.send(:validation_context=, validation_context)
+        set_validation_context(model, validation_context)
         model.errors.clear
 
         model.run_callbacks(:validation) do
@@ -117,7 +117,22 @@ module ActiveRecord::Import # :nodoc:
 
         model.errors.empty?
       ensure
-        model.send(:validation_context=, current_context)
+        set_validation_context(model, current_context)
+      end
+    end
+
+    private
+
+    # ActiveModel's private +validation_context=+ writer was removed in Rails
+    # 8.2 (rails/rails@0f9d1270834a6407a59637650bf910d8ae826169) in favor of a
+    # validation context object reachable through the private
+    # +context_for_validation+ reader. Support both so that validated imports
+    # keep working across all supported ActiveRecord versions.
+    def set_validation_context(model, context)
+      if model.respond_to?(:validation_context=, true)
+        model.send(:validation_context=, context)
+      else
+        model.send(:context_for_validation).context = context
       end
     end
   end

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -341,6 +341,89 @@ describe "#import" do
       end
     end
 
+    # Regression coverage for rails/rails@0f9d1270834a6407a59637650bf910d8ae826169, which removed
+    # ActiveModel's private #validation_context= writer on Rails main (>= 8.2).
+    context "with respect to the model's validation context" do
+      let(:validator) { ActiveRecord::Import::Validator.new(Topic) }
+      let(:valid_topic) { Topic.new(title: "LDAP", author_name: "Jerry Carter", content: "Putting Directories to Work.") }
+
+      it "should import valid models" do
+        assert_difference "Topic.count", +2 do
+          Topic.import valid_models, validate: true
+        end
+      end
+
+      it "should not import invalid models" do
+        assert_no_difference "Topic.count" do
+          Topic.import invalid_models, validate: true
+        end
+      end
+
+      it "should import with validate_with_context" do
+        assert_difference "Topic.count", +2 do
+          Topic.import columns, valid_values_with_context, validate_with_context: :context_test
+        end
+
+        assert_no_difference "Topic.count" do
+          Topic.import columns, valid_values, validate_with_context: :context_test
+        end
+      end
+
+      it "should restore the previous validation context" do
+        validator.send(:set_validation_context, valid_topic, :previous_context)
+
+        assert validator.valid_model?(valid_topic)
+        assert_equal :previous_context, valid_topic.send(:validation_context)
+      end
+
+      it "should restore the previous validation context when validation raises" do
+        exploding_topic = Topic.new(title: "raise_during_validation", author_name: "Jerry Carter", content: "Putting Directories to Work.")
+        validator.send(:set_validation_context, exploding_topic, :previous_context)
+
+        assert_raises(RuntimeError) { validator.valid_model?(exploding_topic) }
+        assert_equal :previous_context, exploding_topic.send(:validation_context)
+      end
+
+      context "when ActiveModel has no private validation_context= writer (Rails main)" do
+        let(:validator) { ActiveRecord::Import::Validator.new(RailsMainValidationContextModel) }
+        let(:context_validator) { ActiveRecord::Import::Validator.new(RailsMainValidationContextModel, validate_with_context: :context_test) }
+        let(:valid_model) { RailsMainValidationContextModel.new(title: "LDAP", author_name: "Jerry Carter") }
+
+        it "should exercise the context_for_validation fallback" do
+          assert_not valid_model.respond_to?(:validation_context=, true)
+          assert valid_model.respond_to?(:context_for_validation, true)
+        end
+
+        it "should validate valid models" do
+          assert validator.valid_model?(valid_model)
+        end
+
+        it "should not validate invalid models" do
+          assert_not validator.valid_model?(RailsMainValidationContextModel.new(title: "LDAP", author_name: ""))
+        end
+
+        it "should validate with validate_with_context" do
+          assert context_validator.valid_model?(RailsMainValidationContextModel.new(title: 1111, author_name: "Jerry Carter"))
+          assert_not context_validator.valid_model?(valid_model)
+        end
+
+        it "should restore the previous validation context" do
+          validator.send(:set_validation_context, valid_model, :previous_context)
+
+          assert validator.valid_model?(valid_model)
+          assert_equal :previous_context, valid_model.validation_context
+        end
+
+        it "should restore the previous validation context when validation raises" do
+          exploding_model = RailsMainValidationContextModel.new(title: "raise_during_validation", author_name: "Jerry Carter")
+          validator.send(:set_validation_context, exploding_model, :previous_context)
+
+          assert_raises(RuntimeError) { validator.valid_model?(exploding_model) }
+          assert_equal :previous_context, exploding_model.validation_context
+        end
+      end
+    end
+
     context "with uniqueness validators included" do
       it "should not import duplicate records" do
         Topic.import columns, valid_values

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -13,6 +13,7 @@ class Topic < ActiveRecord::Base
   validates :word_count, numericality: { greater_than: 0 }, if: :content?
 
   validate -> { errors.add(:title, :validate_failed) if title == 'validate_failed' }
+  validate -> { raise 'validation blew up' if title == 'raise_during_validation' }
   before_validation -> { errors.add(:title, :invalid) if title == 'invalid' }
 
   has_many :books, inverse_of: :topic

--- a/test/support/rails_main_validation_context_model.rb
+++ b/test/support/rails_main_validation_context_model.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Mimics the ActiveModel::Validations API shipped by Rails main (>= 8.2), where the private
+# +validation_context=+ writer was removed in favor of a validation context object reachable
+# through the private +context_for_validation+ reader.
+#
+# See rails/rails@0f9d1270834a6407a59637650bf910d8ae826169.
+#
+# Every currently released ActiveModel still defines +validation_context=+, so it is removed
+# here. That way ActiveRecord::Import::Validator takes the same code path it takes on Rails
+# main no matter which ActiveRecord version the suite is running against.
+class RailsMainValidationContextModel
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+
+  ValidationContext = Struct.new(:context)
+
+  undef_method :validation_context= if method_defined?(:validation_context=) || private_method_defined?(:validation_context=)
+
+  attr_accessor :author_name, :title
+
+  validates_presence_of :author_name
+  validates :title, numericality: { only_integer: true }, on: :context_test
+  validate -> { raise 'validation blew up' if title == 'raise_during_validation' }
+
+  def self.reflect_on_all_associations(_macro = nil)
+    []
+  end
+
+  def initialize(attributes = {})
+    attributes.each { |name, value| public_send("#{name}=", value) }
+  end
+
+  def new_record?
+    true
+  end
+
+  def validation_context
+    context_for_validation.context
+  end
+
+  private
+
+  def context_for_validation
+    @context_for_validation ||= ValidationContext.new
+  end
+end


### PR DESCRIPTION
## Problem

Rails removed the private `ActiveModel::Validations#validation_context=` writer in
rails/rails@0f9d1270834a6407a59637650bf910d8ae826169 (on main as of
rails/rails@bcce5106f8b3d074a91d6efaa4a34b7e4a087f3c, version 8.2.0.alpha), in favor of a
validation context object reached through the private `#context_for_validation` reader.

`ActiveRecord::Import::Validator#valid_model?` calls that writer twice — once to set the
import's validation context and once to restore the caller's context in `ensure`. Against
Rails main, every validated import therefore blows up with:

    NoMethodError: undefined method 'validation_context=' for an instance of <Model>

This affects activerecord-import 2.2.0 and current master. Running the sqlite3 suite against
Rails main before this change gives 3 failures and 114 errors.

## Fix

Add a small private `Validator#set_validation_context(model, context)` helper that uses
`validation_context=` when the writer is present and falls back to
`context_for_validation.context=` otherwise, and use it in both places. The branch is chosen
by method presence rather than by ActiveRecord version, so a single code path serves
ActiveRecord 5.2 through main. Import validation is not disabled and no Rails monkey patch
is introduced.

## Tests

`test/import_test.rb` gains a "with respect to the model's validation context" context
covering valid imports, invalid imports, `validate_with_context`, restoration of the previous
validation context, and restoration when validation raises.

Because every released ActiveModel still defines `validation_context=`, the new fallback
branch would be dead code on the entire existing matrix. `test/support/rails_main_validation_context_model.rb`
adds a small `ActiveModel::Validations` model that removes the writer and implements
`context_for_validation` the way Rails main does, so the fallback is genuinely exercised on
every supported Rails version. Reverting the library change makes 7 of the new tests error.

## CI

Adds `gemfiles/8.2.gemfile`, which tracks the `rails/rails` main branch, plus a matrix entry
for `AR_VERSION=8.2` on Ruby 3.4 (Rails main requires Ruby >= 3.3.1). The job is marked
`experimental` and runs under `continue-on-error`, so upstream churn cannot turn the matrix
red, and it skips `bundler-cache` — a cached lockfile would pin the git source to a stale
revision instead of resolving the current branch head.

## Results

* Rails main (8.2.0.alpha): 224 runs, 560 assertions, 0 failures, 0 errors (was 3 failures,
  114 errors)
* ActiveRecord 8.1, 8.0, 7.2, 7.1, 7.0, 6.1 — sqlite3, sqlite3_proxy, spatialite: all green
* ActiveRecord 8.0 and 7.0 — mysql2, postgresql: all green
* RuboCop: 145 files inspected, no offenses detected

## Note on private APIs

`context_for_validation` is private on Rails main, so this trades one private-API dependency
for another. There is no public way to swap a model's validation context without also running
validations (`valid?(context)`), which `valid_model?` cannot use since it drives the validate
callback chain itself. A public ActiveModel API for scoping a validation context would let
this shim go away entirely.
