### PR TITLE
Avoid quadratic synchronization lookups

### DIFF
--- a/lib/activerecord-import/synchronize.rb
+++ b/lib/activerecord-import/synchronize.rb
@@ -27,17 +27,21 @@ module ActiveRecord # :nodoc:
 
       conditions = {}
 
-      key_values = keys.map { |key| instances.map(&key.to_sym) }
+      key_values = keys.map { |key| instances.map(&key.to_sym).uniq }
       keys.zip(key_values).each { |key, values| conditions[key] = values }
       order = keys.map { |key| "#{key} ASC" }.join(",")
 
       klass = instances.first.class
 
       fresh_instances = klass.unscoped.where(conditions).order(order)
+      fresh_instances_by_key = fresh_instances.each_with_object({}) do |fresh_instance, records_by_key|
+        key = keys.map { |key_column| fresh_instance.send(key_column) }
+        records_by_key[key] ||= fresh_instance
+      end
+
       instances.each do |instance|
-        matched_instance = fresh_instances.detect do |fresh_instance|
-          keys.all? { |key| fresh_instance.send(key) == instance.send(key) }
-        end
+        key = keys.map { |key_column| instance.send(key_column) }
+        matched_instance = fresh_instances_by_key[key]
 
         next unless matched_instance
 

--- a/test/synchronize_test.rb
+++ b/test/synchronize_test.rb
@@ -24,6 +24,15 @@ describe ".synchronize" do
     assert_equal "#{titles[2]}_haha", actual_titles[2], "the third record was not correctly updated"
   end
 
+  it "reloads data using multiple key fields" do
+    Topic.synchronize topics, [:id, :author_name]
+
+    actual_titles = topics.map(&:title)
+    assert_equal "#{titles[0]}_haha", actual_titles[0], "the first record was not correctly updated"
+    assert_equal "#{titles[1]}_haha", actual_titles[1], "the second record was not correctly updated"
+    assert_equal "#{titles[2]}_haha", actual_titles[2], "the third record was not correctly updated"
+  end
+
   it "the synchronized records aren't dirty" do
     # Update the in memory records so they're dirty
     topics.each { |topic| topic.title = 'dirty title' }


### PR DESCRIPTION
## Summary

`synchronize` currently scans every freshly loaded record for every input instance. This makes the in-memory matching step quadratic as batch sizes grow.

This change replaces repeated scans with a keyed lookup:

- Indexes fresh records by their synchronization key in one pass.
- Matches input instances through constant-time hash lookups.
- Reduces matching work from O(n²) to O(n) for equally sized collections.
- Deduplicates values used to build query conditions.
- Preserves the first ordered match when synchronization keys are not unique.

## Verification

- Added composite-key synchronization coverage.
- SQLite tests on Active Record 8.1 pass: 4 runs, 10 assertions, 0 failures.
- Targeted RuboCop, Ruby syntax, and diff checks pass.

