### PR TITLE
Normalize tracked validation failures before synchronizing imported models

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -907,7 +907,9 @@ class ActiveRecord::Base
 
     def set_attributes_and_mark_clean(conn, models, import_result, timestamps, options)
       return if models.nil?
-      models -= import_result.failed_instances
+      failed_instances = import_result.failed_instances
+      failed_instances = failed_instances.map(&:last) if options[:track_validation_failures]
+      models -= failed_instances
 
       # if ids were returned for all models we know all were updated
       if models.size == import_result.ids.size


### PR DESCRIPTION
## Summary

Fixes #888. With `track_validation_failures: true`, failure entries are `[index, model]` tuples. Subtracting those tuples from the input models removes nothing: invalid models become marked persisted and valid models lose returned-ID synchronization.

Normalize the failure entries only for internal model filtering. Preserve the public failure tuples unchanged. This restores valid parent IDs and their recursive children.

## Reproduction

For PostgreSQL models `AuditParent` (validates name presence; has_many audit_children) and `AuditChild` (belongs_to audit_parent):

```ruby
parents = ['first', nil, 'third'].map do |name|
  parent = AuditParent.new(name: name)
  parent.audit_children.build(name: 'child')
  parent
end
result = AuditParent.import(parents, recursive: true, track_validation_failures: true)
p [AuditParent.count, AuditChild.count, parents.map(&:id)]
p result.failed_instances.map(&:first)
```

On a fresh database before: 2 parents, **0 children**, all in-memory IDs nil. After: 2 parents, **2 children**, IDs `[1, nil, 2]`; failure index remains `[1]` and the invalid parent remains unpersisted. An additional tracked/untracked validation matrix verifies valid ID assignment and invalid-state preservation.

This is separate from #858 (invalid parents with preassigned IDs), whose general recursive-filtering proposal is not duplicated here. Aborted `all_or_none` post-processing is handled separately.

## Verification and limitations

Ruby 4.0.6 / Active Record 8.1.3.1. The unchanged existing suites pass both before and after this individual patch: PostgreSQL 15.19: **304 runs, 792 assertions**; SQLite 2.2.0: **225 runs, 563 assertions**; no failures/errors/skips. Targeted RuboCop, Ruby syntax and whitespace checks pass.

Checks use an isolated PostgreSQL Unix socket and an in-memory SQLite database; no production services. A temporary external verification Gemfile supplies the existing test dependencies, Minitest 5 and Ruby 4's extracted rdoc/ostruct libraries. No tests, gem versions, runtime dependencies or upstream development configuration were changed. The full historical Ruby/database matrix was not run locally.

## Breaking changes

None intended. Public signatures and result shapes are unchanged; the behavior correction is described above.

Prepared with Codex assistance; the source change and reproduction were reviewed and executed.
