### PR TITLE
Preserve model state when all-or-none validation aborts an import

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -769,6 +769,8 @@ class ActiveRecord::Base
           import_without_validations_or_callbacks( conn, column_names, array_of_attributes, options )
         end
 
+        return return_obj if options[:all_or_none] && return_obj.failed_instances.any?
+
         if options[:synchronize]
           sync_keys = options[:synchronize_keys] || Array(primary_key)
           synchronize( options[:synchronize], sync_keys)


### PR DESCRIPTION
## Summary

Return the existing import result immediately when `all_or_none` aborts on validation failures. No insert occurred, so subsequent synchronization, marking models clean/persisted and recursive import must not run.

Previously, a valid new model became `persisted?` with a nil ID even though no row was inserted. A requested synchronization also discarded unsaved edits on existing models.

## Reproduction

For a PostgreSQL model `AuditParent` validating name presence:

```ruby
existing = AuditParent.create!(name: 'stored')
existing.name = 'unsaved update'
fresh = AuditParent.new(name: 'unsaved new')
invalid = AuditParent.new
result = AuditParent.import(
  [existing, fresh, invalid],
  all_or_none: true,
  on_duplicate_key_update: [:name],
  synchronize: [existing]
)
p [result.num_inserts, fresh.persisted?, existing.name, existing.changed?]
```

Before: `[0, true, "stored", false]`.
After: `[0, false, "unsaved update", true]`.

Repeated with tracked failure tuples enabled and with a pending recursive child; no database changes occur. Successful imports still follow their existing processing path. This does not implement atomic rollback for failures during recursive child validation.

## Verification and limitations

Ruby 4.0.6 / Active Record 8.1.3.1. The unchanged existing suites pass both before and after this individual patch: PostgreSQL 15.19: **304 runs, 792 assertions**; SQLite 2.2.0: **225 runs, 563 assertions**; no failures/errors/skips. Targeted RuboCop, Ruby syntax and whitespace checks pass.

Checks use an isolated PostgreSQL Unix socket and an in-memory SQLite database; no production services. A temporary external verification Gemfile supplies the existing test dependencies, Minitest 5 and Ruby 4's extracted rdoc/ostruct libraries. No tests, gem versions, runtime dependencies or upstream development configuration were changed. The full historical Ruby/database matrix was not run locally.

## Breaking changes

None intended. Public signatures and result shapes are unchanged; the behavior correction is described above.

Prepared with Codex assistance; the source change and reproduction were reviewed and executed.
