### PR TITLE
Include association keys when importing models with explicit columns

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -170,6 +170,7 @@ class ActiveRecord::Associations::CollectionAssociation
       if args.length == 2
         models = args.last
         column_names = args.first.dup
+        symbolized_column_names = column_names.map(&:to_sym)
       else
         models = args.first
         column_names = symbolized_column_names
@@ -177,6 +178,10 @@ class ActiveRecord::Associations::CollectionAssociation
 
       unless symbolized_column_names.include?(symbolized_foreign_key)
         column_names << symbolized_foreign_key
+      end
+
+      if reflection.type && !symbolized_column_names.include?(reflection.type.to_sym)
+        column_names << reflection.type.to_sym
       end
 
       models.each do |m|


### PR DESCRIPTION
## Summary

When importing model instances through a collection with an explicit column list, check that selected list when adding the owner foreign key. The old code checked every schema column instead, so it omitted the foreign key from the INSERT even though the in-memory model had it.

Also include the polymorphic type column when required, matching the existing hash/value import paths.

## Reproduction

For `AuditParent has_many :audit_children`:

```ruby
parent = AuditParent.create!
parent.audit_children.import([:name], [AuditChild.new(name: 'child')], validate: false)
p AuditChild.last.audit_parent_id
```

Before: nil. After: the parent ID. The same failure/fix is reproduced with string column names.

For `has_many :attachments, class_name: 'AuditChild', as: :attachable`, importing `[:name]` previously leaves both `attachable_id` and `attachable_type` nil; afterward both identify the owner.

Focused checks also cover already-included string/symbol foreign keys, avoiding duplicate columns. Input column arrays remain copied, not mutated. Composite association key support and STI polymorphic naming are outside this patch.

## Verification and limitations

Ruby 4.0.6 / Active Record 8.1.3.1. The unchanged existing suites pass both before and after this individual patch: PostgreSQL 15.19: **304 runs, 792 assertions**; SQLite 2.2.0: **225 runs, 563 assertions**; no failures/errors/skips. Targeted RuboCop, Ruby syntax and whitespace checks pass.

Checks use an isolated PostgreSQL Unix socket and an in-memory SQLite database; no production services. A temporary external verification Gemfile supplies the existing test dependencies, Minitest 5 and Ruby 4's extracted rdoc/ostruct libraries. No tests, gem versions, runtime dependencies or upstream development configuration were changed. The full historical Ruby/database matrix was not run locally.

## Breaking changes

None intended. Public signatures and result shapes are unchanged; the behavior correction is described above.

Prepared with Codex assistance; the source change and reproduction were reviewed and executed.
