### PR TITLE
Append returned batch IDs and results without recopying prior batches

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -877,8 +877,8 @@ class ActiveRecord::Base
             "#{model_name} Create Many" )
 
           number_inserted += result.num_inserts
-          ids += result.ids
-          results += result.results
+          ids.concat(result.ids)
+          results.concat(result.results)
           affected_rows = result.affected_rows.nil? ? nil : (affected_rows || 0) + result.affected_rows
           current_batch += 1
 


### PR DESCRIPTION
## Summary

Use `concat` for the locally owned ID/result accumulators. Repeated `+=` creates a new array and copies every prior batch after each INSERT; accumulation becomes quadratic in the number of batches.

No query, transaction, return ordering or adapter result arrays change. Only the two fresh local accumulators are mutated.

## Measurement and reproduction

Ruby 4.0.6, two result arrays, 100 values per batch; identical final arrays/checksums verified:

| Batches | Rows | Previous accumulation | concat |
| --- | --- | --- | --- |
| 100 | 10,000 | 0.000675s | 0.000038s |
| 1,000 | 100,000 | 0.019594s | 0.000250s |
| 2,000 | 200,000 | 0.061483s | 0.000491s |

This bounded microbenchmark measures accumulation only, **not end-to-end database throughput**. For the 2,000-batch case, allocated Ruby objects fall from 4,003 to 3 (measurement includes the final equality check).

```ruby
values = (1..100).to_a
ids = []
results = []
2000.times do
  ids.concat(values)     # previously: ids += values
  results.concat(values)
end
raise unless ids == values * 2000 && results == ids
```

An actual PostgreSQL import of 2,000 models with `batch_size: 2, returning: :name` executes 1,000 batches and preserves all returned IDs and values in order.

## Verification and limitations

Ruby 4.0.6 / Active Record 8.1.3.1. The unchanged existing suites pass both before and after this individual patch: PostgreSQL 15.19: **304 runs, 792 assertions**; SQLite 2.2.0: **225 runs, 563 assertions**; no failures/errors/skips. Targeted RuboCop, Ruby syntax and whitespace checks pass.

Checks use an isolated PostgreSQL Unix socket and an in-memory SQLite database; no production services. A temporary external verification Gemfile supplies the existing test dependencies, Minitest 5 and Ruby 4's extracted rdoc/ostruct libraries. No tests, gem versions, runtime dependencies or upstream development configuration were changed. The full historical Ruby/database matrix was not run locally.

## Breaking changes

None intended. Public signatures and result shapes are unchanged; the behavior correction is described above.

Prepared with Codex assistance; the source change and reproduction were reviewed and executed.
