### PR TITLE
Quote PostgreSQL returning column names safely

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -104,7 +104,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
     selections += Array(options[:returning]) if options[:returning].present?
 
     selections.map do |selection|
-      column_names.include?(selection.to_s) ? "\"#{selection}\"" : selection
+      column_names.include?(selection.to_s) ? quote_column_name(selection) : selection
     end
   end
 


### PR DESCRIPTION
Summary

Use the PostgreSQL adapter to quote known returning columns instead of manually wrapping their names. Raw SQL selections remain untouched.

Reproduction

A model column containing an embedded quote currently produces invalid RETURNING SQL. The adapter-quoted selection returns the correct value.

Verification

PostgreSQL 15.19 focused reproduction; existing PostgreSQL 304 runs / 792 assertions and SQLite 225 / 563; syntax and targeted RuboCop pass. No tests or generated files were modified.

Compatibility

Only schema-known column identifiers change. Existing raw SQL returning expressions retain their current contract. Prepared with Codex assistance.