### PR TITLE
Quote generated PostgreSQL conflict targets

### DIFF
--- a/lib/activerecord-import/adapters/postgresql_adapter.rb
+++ b/lib/activerecord-import/adapters/postgresql_adapter.rb
@@ -207,7 +207,7 @@ module ActiveRecord::Import::PostgreSQLAdapter
   end
 
   def sql_for_default_conflict_target( table_name, primary_key )
-    conflict_target = Array(primary_key).join(', ')
+    conflict_target = Array(primary_key).map { |key| quote_column_name(key) }.join(', ')
     "(#{conflict_target}) " if conflict_target.present?
   end
 


### PR DESCRIPTION
Summary

Quote model-derived primary-key identifiers when PostgreSQL builds the default ON CONFLICT target. Explicit conflict targets, predicates, constraints, and raw expressions remain unchanged.

Reproduction

An upsert using a mixed-case primary key currently emits an invalid unquoted default target; the quoted target succeeds.

Verification

PostgreSQL 15.19 focused reproduction; existing PostgreSQL 304 runs / 792 assertions and SQLite 225 / 563; syntax and targeted RuboCop pass. No tests or generated files were modified.

Compatibility

This changes only internally generated identifiers and preserves the documented explicit-expression surface. Prepared with Codex assistance.