### PR TITLE
Track the active validation callback class

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -31,6 +31,7 @@ module ActiveRecord::Import # :nodoc:
     end
 
     def init_validations(klass)
+      @validator_class = klass
       @validate_callbacks = klass._validate_callbacks.dup
 
       @validate_callbacks.each_with_index do |callback, i|


### PR DESCRIPTION
Summary

Update the cached validator class whenever validation callbacks are rebuilt for a different model class.

Reproduction

After the merged heterogeneous-STI validation change, a subclass-to-base sequence can keep the subclass callback chain because the tracker is never advanced. Subclass, base, and subclass records now each use their own callbacks.

Verification

Focused heterogeneous validation sequence; existing PostgreSQL 304 runs / 792 assertions and SQLite 225 / 563; syntax and targeted RuboCop pass. No tests or generated files were modified.

Compatibility

Homogeneous imports and validation result shapes are unchanged. Prepared with Codex assistance.