### PR TITLE
Reject import rows with missing values

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -1071,6 +1071,10 @@ class ActiveRecord::Base
     # and +array_of_attributes+.
     def values_sql_for_columns_and_attributes(conn, columns, array_of_attributes) # :nodoc:
       array_of_attributes.map do |arr|
+        if arr.length < columns.length
+          raise ArgumentError, "Number of values (#{arr.length}) is less than number of columns (#{columns.length})"
+        end
+
         my_values = arr.each_with_index.map do |val, j|
           column = columns[j]
 


### PR DESCRIPTION
Summary

Validate short value rows before quoting or SQL generation, matching the existing early rejection of over-wide rows.

Reproduction

A row with fewer values than columns currently reaches the database as malformed INSERT SQL. Both short and long rows now raise a focused ArgumentError before execution.

Verification

Focused model and association row-width checks; existing PostgreSQL 304 runs / 792 assertions and SQLite 225 / 563; syntax and targeted RuboCop pass. No tests or generated files were modified.

Compatibility

Correctly sized rows and public result shapes are unchanged. Prepared with Codex assistance.