### PR TITLE
Support composite keys in association imports

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -154,7 +154,7 @@ class ActiveRecord::Associations::CollectionAssociation
     options = args.last.is_a?(Hash) ? args.pop : {}
 
     model_klass = reflection.klass
-    symbolized_foreign_key = reflection.foreign_key.to_sym
+    symbolized_foreign_keys = Array(reflection.foreign_key).map(&:to_sym)
 
     symbolized_column_names = if model_klass.connection_pool.with_connection { |conn| conn.respond_to?(:supports_virtual_columns?) && conn.supports_virtual_columns? }
       model_klass.columns.reject(&:virtual?).map { |c| c.name.to_sym }
@@ -162,8 +162,9 @@ class ActiveRecord::Associations::CollectionAssociation
       model_klass.column_names.map(&:to_sym)
     end
 
-    owner_primary_key = reflection.active_record_primary_key.to_sym
-    owner_primary_key_value = owner.send(owner_primary_key)
+    owner_primary_keys = Array(reflection.active_record_primary_key).map(&:to_sym)
+    owner_key_values = owner_primary_keys.map { |key| owner.public_send(key) }
+    owner_key_values_by_foreign_key = symbolized_foreign_keys.zip(owner_key_values).to_h
     owner_polymorphic_name = if reflection.type
       if owner.class.respond_to?(:polymorphic_name)
         owner.class.polymorphic_name
@@ -183,8 +184,8 @@ class ActiveRecord::Associations::CollectionAssociation
         column_names = symbolized_column_names
       end
 
-      unless symbolized_column_names.include?(symbolized_foreign_key)
-        column_names << symbolized_foreign_key
+      symbolized_foreign_keys.each do |foreign_key|
+        column_names << foreign_key unless symbolized_column_names.include?(foreign_key)
       end
 
       if reflection.type && !symbolized_column_names.include?(reflection.type.to_sym)
@@ -192,7 +193,9 @@ class ActiveRecord::Associations::CollectionAssociation
       end
 
       models.each do |m|
-        m.public_send "#{symbolized_foreign_key}=", owner_primary_key_value
+        owner_key_values_by_foreign_key.each do |foreign_key, value|
+          m.public_send "#{foreign_key}=", value
+        end
         m.public_send "#{reflection.type}=", owner_polymorphic_name if reflection.type
       end
 
@@ -212,8 +215,8 @@ class ActiveRecord::Associations::CollectionAssociation
 
       required_column_names = column_names.dup
       symbolized_column_names = column_names.map(&:to_sym)
-      unless symbolized_column_names.include?(symbolized_foreign_key)
-        column_names << symbolized_foreign_key
+      symbolized_foreign_keys.each do |foreign_key|
+        column_names << foreign_key unless symbolized_column_names.include?(foreign_key)
       end
 
       if reflection.type && !symbolized_column_names.include?(reflection.type.to_sym)
@@ -227,8 +230,8 @@ class ActiveRecord::Associations::CollectionAssociation
 
         column_names.map do |key|
           symbolized_key = key.to_sym
-          if symbolized_key == symbolized_foreign_key
-            owner_primary_key_value
+          if owner_key_values_by_foreign_key.key?(symbolized_key)
+            owner_key_values_by_foreign_key[symbolized_key]
           elsif reflection.type && symbolized_key == reflection.type.to_sym
             owner_polymorphic_name
           else
@@ -253,12 +256,14 @@ class ActiveRecord::Associations::CollectionAssociation
 
       symbolized_column_names = column_names.map(&:to_sym)
 
-      if symbolized_column_names.include?(symbolized_foreign_key)
-        index = symbolized_column_names.index(symbolized_foreign_key)
-        array_of_attributes.each { |attrs| attrs[index] = owner_primary_key_value }
-      else
-        column_names << symbolized_foreign_key
-        array_of_attributes.each { |attrs| attrs << owner_primary_key_value }
+      owner_key_values_by_foreign_key.each do |foreign_key, value|
+        if symbolized_column_names.include?(foreign_key)
+          index = symbolized_column_names.index(foreign_key)
+          array_of_attributes.each { |attrs| attrs[index] = value }
+        else
+          column_names << foreign_key
+          array_of_attributes.each { |attrs| attrs << value }
+        end
       end
 
       if reflection.type

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -164,6 +164,13 @@ class ActiveRecord::Associations::CollectionAssociation
 
     owner_primary_key = reflection.active_record_primary_key.to_sym
     owner_primary_key_value = owner.send(owner_primary_key)
+    owner_polymorphic_name = if reflection.type
+      if owner.class.respond_to?(:polymorphic_name)
+        owner.class.polymorphic_name
+      else
+        owner.class.base_class
+      end
+    end
 
     # assume array of model objects
     if args.last.is_a?( Array ) && args.last.first.is_a?(ActiveRecord::Base)
@@ -186,7 +193,7 @@ class ActiveRecord::Associations::CollectionAssociation
 
       models.each do |m|
         m.public_send "#{symbolized_foreign_key}=", owner_primary_key_value
-        m.public_send "#{reflection.type}=", owner.class.name if reflection.type
+        m.public_send "#{reflection.type}=", owner_polymorphic_name if reflection.type
       end
 
       model_klass.bulk_import column_names, models, options
@@ -223,7 +230,7 @@ class ActiveRecord::Associations::CollectionAssociation
           if symbolized_key == symbolized_foreign_key
             owner_primary_key_value
           elsif reflection.type && symbolized_key == reflection.type.to_sym
-            owner.class.name
+            owner_polymorphic_name
           else
             h[key]
           end
@@ -258,10 +265,10 @@ class ActiveRecord::Associations::CollectionAssociation
         symbolized_type = reflection.type.to_sym
         if symbolized_column_names.include?(symbolized_type)
           index = symbolized_column_names.index(symbolized_type)
-          array_of_attributes.each { |attrs| attrs[index] = owner.class.name }
+          array_of_attributes.each { |attrs| attrs[index] = owner_polymorphic_name }
         else
           column_names << symbolized_type
-          array_of_attributes.each { |attrs| attrs << owner.class.name }
+          array_of_attributes.each { |attrs| attrs << owner_polymorphic_name }
         end
       end
 

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -203,6 +203,7 @@ class ActiveRecord::Associations::CollectionAssociation
         allow_extra_hash_keys = false
       end
 
+      required_column_names = column_names.dup
       symbolized_column_names = column_names.map(&:to_sym)
       unless symbolized_column_names.include?(symbolized_foreign_key)
         column_names << symbolized_foreign_key
@@ -213,14 +214,15 @@ class ActiveRecord::Associations::CollectionAssociation
       end
 
       array_of_attributes = array_of_hashes.map do |h|
-        error_message = model_klass.send(:validate_hash_import, h, symbolized_column_names, allow_extra_hash_keys)
+        error_message = model_klass.send(:validate_hash_import, h, required_column_names, allow_extra_hash_keys)
 
         raise ArgumentError, error_message if error_message
 
         column_names.map do |key|
-          if key == symbolized_foreign_key
+          symbolized_key = key.to_sym
+          if symbolized_key == symbolized_foreign_key
             owner_primary_key_value
-          elsif reflection.type && key == reflection.type.to_sym
+          elsif reflection.type && symbolized_key == reflection.type.to_sym
             owner.class.name
           else
             h[key]

--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -170,6 +170,7 @@ class ActiveRecord::Associations::CollectionAssociation
       if args.length == 2
         models = args.last
         column_names = args.first.dup
+        symbolized_column_names = column_names.map(&:to_sym)
       else
         models = args.first
         column_names = symbolized_column_names
@@ -177,6 +178,10 @@ class ActiveRecord::Associations::CollectionAssociation
 
       unless symbolized_column_names.include?(symbolized_foreign_key)
         column_names << symbolized_foreign_key
+      end
+
+      if reflection.type && !symbolized_column_names.include?(reflection.type.to_sym)
+        column_names << reflection.type.to_sym
       end
 
       models.each do |m|


### PR DESCRIPTION
Summary

Map composite owner primary-key tuples onto composite association foreign keys for direct model, hash, and value imports. Scalar associations retain their existing path.

Dependency

This is a stacked draft on #905, #909, and #910. The branch includes those prerequisite changes; the final composite-key commit is f5939e0d200c6c92b4b60998b12f8182c3811fdc. It should be rebased after the prerequisite PRs land.

Reproduction

Collection import currently calls to_sym on key arrays and fails before import. Four composite association forms now receive the complete owner tuple.

Verification

Focused PostgreSQL composite-association models; full combined PostgreSQL 304 runs / 792 assertions and SQLite 225 / 563; Active Record 7.2 SQLite 225 / 563; syntax and targeted RuboCop pass. No tests or generated files were modified.

Compatibility

Scalar keys and existing composite-key paths outside direct collection imports are unchanged. Prepared with Codex assistance.